### PR TITLE
Null content-length headers parsing is really inefficient

### DIFF
--- a/src/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -1039,8 +1039,15 @@ public abstract class FileUploadBase {
         }
 
         private long getContentLength(FileItemHeaders pHeaders) {
+            String contentLength = pHeaders.getHeader(CONTENT_LENGTH);
+            if (contentLength == null) {
+                // do not use the exception mechanism to
+                // handle null values in such critical path
+                // it's incredibly inefficient
+                return -1;
+            }
             try {
-                return Long.parseLong(pHeaders.getHeader(CONTENT_LENGTH));
+                return Long.parseLong(contentLength);
             } catch (Exception e) {
                 return -1;
             }


### PR DESCRIPTION
Throwing an exception to handle null content-length headers is really inefficient, particularly when you're parsing big multi-parts requests (where they are always null)
