### PR TITLE
Eliminate HttpServletRequest#getContentLength

### DIFF
--- a/src/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -917,7 +917,7 @@ public abstract class FileUploadBase {
             InputStream input = ctx.getInputStream();
 
             if (sizeMax >= 0) {
-                int requestSize = ctx.getContentLength();
+                long requestSize = ctx.getContentLength();
                 if (requestSize == -1) {
                     input = new LimitedInputStream(input, sizeMax) {
                         protected void raiseError(long pSizeMax, long pCount)

--- a/src/java/org/apache/commons/fileupload/RequestContext.java
+++ b/src/java/org/apache/commons/fileupload/RequestContext.java
@@ -51,7 +51,7 @@ public interface RequestContext {
      *
      * @return The content length of the request.
      */
-    int getContentLength();
+    long getContentLength();
 
     /**
      * Retrieve the input stream for the request.

--- a/src/java/org/apache/commons/fileupload/portlet/PortletRequestContext.java
+++ b/src/java/org/apache/commons/fileupload/portlet/PortletRequestContext.java
@@ -78,8 +78,8 @@ public class PortletRequestContext implements RequestContext {
      *
      * @return The content length of the request.
      */
-    public int getContentLength() {
-        return request.getContentLength();
+    public long getContentLength() {
+        return request.getContentLength(); // TODO get as long somehow
     }
 
     /**

--- a/src/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
+++ b/src/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
@@ -19,6 +19,7 @@ package org.apache.commons.fileupload.servlet;
 import java.io.InputStream;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.RequestContext;
 
 /**
@@ -78,8 +79,14 @@ public class ServletRequestContext implements RequestContext {
      *
      * @return The content length of the request.
      */
-    public int getContentLength() {
-        return request.getContentLength();
+    public long getContentLength() {
+        long size = -1;
+		try {
+			size = Long.parseLong(request
+					.getHeader(FileUploadBase.CONTENT_LENGTH));
+        } catch (NumberFormatException e) {
+            }
+        return size;
     }
 
     /**
@@ -100,8 +107,8 @@ public class ServletRequestContext implements RequestContext {
      */
     public String toString() {
         return "ContentLength="
-            + this.getContentLength()
-            + ", ContentType="
-            + this.getContentType();
+                + this.getContentLength()
+                + ", ContentType="
+                + this.getContentType();
     }
 }

--- a/src/test/org/apache/commons/fileupload/MockHttpServletRequest.java
+++ b/src/test/org/apache/commons/fileupload/MockHttpServletRequest.java
@@ -44,7 +44,7 @@ class MockHttpServletRequest implements HttpServletRequest
 {
 
 	private final InputStream m_requestData;
-	private final int length;
+	private final long length;
 	private String m_strContentType;
 	private Map m_headers = new java.util.HashMap();
 
@@ -66,13 +66,15 @@ class MockHttpServletRequest implements HttpServletRequest
 	 */
 	public MockHttpServletRequest(
 			final InputStream requestData,
-			final int requestLength,
+			final long requestLength,
 			final String strContentType)
 	{
 		m_requestData = requestData;
 		length = requestLength;
+		m_headers.put(FileUploadBase.CONTENT_LENGTH, "" + length);
 		m_strContentType = strContentType;
 		m_headers.put(FileUploadBase.CONTENT_TYPE, strContentType);
+
 	}
 
 	/**
@@ -323,7 +325,7 @@ class MockHttpServletRequest implements HttpServletRequest
 		}
 		else
 		{
-			iLength = length;
+			iLength = (int) length; // FIXME
 		}
 		return iLength;
 	}
@@ -545,7 +547,7 @@ class MockHttpServletRequest implements HttpServletRequest
 			return in.read();
 		}
 
-		public int read(byte b[], int off, int len) throws IOException 
+		public int read(byte b[], int off, int len) throws IOException
 		{
 		    return in.read(b, off, len);
 		}


### PR DESCRIPTION
 to allow correct progress report for 2Gb+ files

FIXME: PortletRequestContext needs fixing (it is unchanged, so 2Gb+ uplaod in portlet is not yet correctly reported)
