### PR TITLE
Update DiskFileItem.java: Avoiding NPE when not explicitely initializ…

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
@@ -210,11 +210,11 @@ public class DiskFileItem
     public InputStream getInputStream()
         throws IOException {
         if (!isInMemory()) {
-            return new FileInputStream(dfos.getFile());
+            return new FileInputStream(getOutputStream().getFile());
         }
 
         if (cachedContent == null) {
-            cachedContent = dfos.getData();
+            cachedContent = getOutputStream().getData();
         }
         return new ByteArrayInputStream(cachedContent);
     }
@@ -271,7 +271,7 @@ public class DiskFileItem
         if (cachedContent != null) {
             return true;
         }
-        return dfos.isInMemory();
+        return getOutputStream().isInMemory();
     }
 
     /**
@@ -284,10 +284,10 @@ public class DiskFileItem
             return size;
         } else if (cachedContent != null) {
             return cachedContent.length;
-        } else if (dfos.isInMemory()) {
-            return dfos.getData().length;
+        } else if (getOutputStream().isInMemory()) {
+            return getOutputStream().getData().length;
         } else {
-            return dfos.getFile().length();
+            return getOutputStream().getFile().length();
         }
     }
 
@@ -301,8 +301,8 @@ public class DiskFileItem
      */
     public byte[] get() {
         if (isInMemory()) {
-            if (cachedContent == null && dfos != null) {
-                cachedContent = dfos.getData();
+            if (cachedContent == null && getOutputStream() != null) {
+                cachedContent = getOutputStream().getData();
             }
             return cachedContent;
         }
@@ -311,7 +311,7 @@ public class DiskFileItem
         InputStream fis = null;
 
         try {
-            fis = new FileInputStream(dfos.getFile());
+            fis = new FileInputStream(getOutputStream().getFile());
             IOUtils.readFully(fis, fileData);
         } catch (IOException e) {
             fileData = null;

--- a/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
@@ -6,7 +6,10 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-
+/**
+ * Some of the methods of the {@link DiskFileItem} rely on the {@link java.io.OutputStream} of the underlying {@link File}.
+ * Therefore we need to make sure that the output stream is initialized on time, to avoid {@link NullPointerException}s.
+ */
 public class DiskFileItemOutputStreamInitTest {
 
     private DiskFileItem diskFileItem;
@@ -39,10 +42,28 @@ public class DiskFileItemOutputStreamInitTest {
     }
 
     @Test
-    public void testGetSizeWithAccessingOutputStreamBefore() throws IOException {
-        // Have to initiate the outputstream, so internal functions in DiskFileItem work.
+    public void testGetInputStreamWithoutAccessingOutputStreamBefore() throws IOException {
+        diskFileItem.getInputStream();
+    }
+
+    @Test
+    public void testIsInMemoryWithoutAccessingOutputStreamBefore() {
+        diskFileItem.getSize();
+    }
+
+    @Test
+    public void testGetWithoutAccessingOutputStreamBefore() {
+        diskFileItem.get();
+    }
+
+    @Test
+    public void testGetterWithAccessingOutputStreamBefore() throws IOException {
+        // Have to initiate the output stream, so internal functions in DiskFileItem work.
         diskFileItem.getOutputStream();
         diskFileItem.getSize();
+        diskFileItem.getInputStream();
+        diskFileItem.isInMemory();
+        diskFileItem.get();
     }
 
 }

--- a/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
@@ -33,7 +33,7 @@ public class DiskFileItemOutputStreamInitTest {
     public void tearDown() throws Exception {
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testGetSizeWithoutAccessingOutputStreamBefore() {
         diskFileItem.getSize();
     }

--- a/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DiskFileItemOutputStreamInitTest.java
@@ -1,0 +1,48 @@
+import org.apache.commons.fileupload.disk.DiskFileItem;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+
+public class DiskFileItemOutputStreamInitTest {
+
+    private DiskFileItem diskFileItem;
+
+    /**
+     * @throws Exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        File file = new File("");
+        diskFileItem = new DiskFileItem(null,
+                                        "application/txt",
+                                        false,
+                                        "file.txt",
+                                        1000,
+                                        file);
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testGetSizeWithoutAccessingOutputStreamBefore() {
+        diskFileItem.getSize();
+    }
+
+    @Test
+    public void testGetSizeWithAccessingOutputStreamBefore() throws IOException {
+        // Have to initiate the outputstream, so internal functions in DiskFileItem work.
+        diskFileItem.getOutputStream();
+        diskFileItem.getSize();
+    }
+
+}


### PR DESCRIPTION
…ing the outputstream

When accessing e.g. getSize() on a DiskFileItem before having called getOutputStream() a NullPointerException would be thrown. Consequent use of the "intelligent" getter already in place avoids this issue.