### PR TITLE
improve GC by avoiding FileInput/Output-Streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,8 +177,8 @@
   </issueManagement>
 
   <properties>
-    <maven.compiler.source>1.5</maven.compiler.source>
-    <maven.compiler.target>1.5</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <commons.componentid>fileupload</commons.componentid>
     <commons.release.version>1.4</commons.release.version>
     <commons.release.desc>(requires Java ${maven.compiler.target} or later)</commons.release.desc>

--- a/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
@@ -28,6 +28,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -210,7 +211,7 @@ public class DiskFileItem
     public InputStream getInputStream()
         throws IOException {
         if (!isInMemory()) {
-            return new FileInputStream(dfos.getFile());
+            return Files.newInputStream(dfos.getFile().toPath());
         }
 
         if (cachedContent == null) {
@@ -311,7 +312,7 @@ public class DiskFileItem
         InputStream fis = null;
 
         try {
-            fis = new FileInputStream(dfos.getFile());
+            fis = Files.newInputStream(dfos.getFile().toPath());
             IOUtils.readFully(fis, fileData);
         } catch (IOException e) {
             fileData = null;
@@ -383,9 +384,9 @@ public class DiskFileItem
      */
     public void write(File file) throws Exception {
         if (isInMemory()) {
-            FileOutputStream fout = null;
+            OutputStream fout = null;
             try {
-                fout = new FileOutputStream(file);
+                fout = Files.newOutputStream(file.toPath());
                 fout.write(get());
                 fout.close();
             } finally {


### PR DESCRIPTION
bump compiler target from 1.5 to 1.7

see:  https://bugs.openjdk.java.net/browse/JDK-8080225