### PR TITLE
FILEUPLOAD-286: allow default charset to be overridden.

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
@@ -152,6 +152,12 @@ public class DiskFileItem
      */
     private FileItemHeaders headers;
 
+    /**
+     * Default content charset to be used when no explicit charset
+     * parameter is provided by the sender.
+     */
+    private String defaultCharset = DEFAULT_CHARSET;
+
     // ----------------------------------------------------------- Constructors
 
     /**
@@ -338,7 +344,7 @@ public class DiskFileItem
         byte[] rawdata = get();
         String charset = getCharSet();
         if (charset == null) {
-            charset = DEFAULT_CHARSET;
+            charset = defaultCharset;
         }
         try {
             return new String(rawdata, charset);
@@ -476,7 +482,7 @@ public class DiskFileItem
      *
      * @throws IOException if an error occurs.
      */
-    public OutputStream getOutputStream()
+    public OutputStream getOutputStream() 
         throws IOException {
         if (dfos == null) {
             File outputFile = getTempFile();
@@ -601,4 +607,21 @@ public class DiskFileItem
         headers = pHeaders;
     }
 
+    /**
+     * Returns the default charset for use when no explicit charset
+     * parameter is provided by the sender.
+     * @return the default charset
+     */
+    public String getDefaultCharset() {
+        return defaultCharset;
+    }
+
+    /**
+     * Sets the default charset for use when no explicit charset
+     * parameter is provided by the sender.
+     * @param charset the default charset
+     */
+    public void setDefaultCharset(String charset) {
+        defaultCharset = charset;
+    }
 }

--- a/src/main/java/org/apache/commons/fileupload/disk/DiskFileItemFactory.java
+++ b/src/main/java/org/apache/commons/fileupload/disk/DiskFileItemFactory.java
@@ -95,6 +95,12 @@ public class DiskFileItemFactory implements FileItemFactory {
      */
     private FileCleaningTracker fileCleaningTracker;
 
+    /**
+     * Default content charset to be used when no explicit charset
+     * parameter is provided by the sender.
+     */
+    private String defaultCharset = DiskFileItem.DEFAULT_CHARSET;
+
     // ----------------------------------------------------------- Constructors
 
     /**
@@ -192,6 +198,7 @@ public class DiskFileItemFactory implements FileItemFactory {
             boolean isFormField, String fileName) {
         DiskFileItem result = new DiskFileItem(fieldName, contentType,
                 isFormField, fileName, sizeThreshold, repository);
+        result.setDefaultCharset(defaultCharset);
         FileCleaningTracker tracker = getFileCleaningTracker();
         if (tracker != null) {
             tracker.track(result.getTempFile(), result);
@@ -222,4 +229,21 @@ public class DiskFileItemFactory implements FileItemFactory {
         fileCleaningTracker = pTracker;
     }
 
+    /**
+     * Returns the default charset for use when no explicit charset
+     * parameter is provided by the sender.
+     * @return the default charset
+     */
+    public String getDefaultCharset() {
+        return defaultCharset;
+    }
+
+    /**
+     * Sets the default charset for use when no explicit charset
+     * parameter is provided by the sender.
+     * @param charset the default charset
+     */
+    public void setDefaultCharset(String charset) {
+        defaultCharset = charset;
+    }
 }

--- a/src/test/java/org/apache/commons/fileupload/DiskFileItemSerializeTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DiskFileItemSerializeTest.java
@@ -98,7 +98,7 @@ public class DiskFileItemSerializeTest {
      * configured threshold.
      */
     @Test
-    public void testBelowThreshold() throws Exception {
+    public void testBelowThreshold() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold - 1);
         testInMemoryObject(testFieldValueBytes);
@@ -109,7 +109,7 @@ public class DiskFileItemSerializeTest {
      * configured threshold.
      */
     @Test
-    public void testThreshold() throws Exception {
+    public void testThreshold() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold);
         testInMemoryObject(testFieldValueBytes);
@@ -120,7 +120,7 @@ public class DiskFileItemSerializeTest {
      * configured threshold.
      */
     @Test
-    public void testAboveThreshold() throws Exception {
+    public void testAboveThreshold() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold + 1);
         FileItem item = createFileItem(testFieldValueBytes);
@@ -137,7 +137,7 @@ public class DiskFileItemSerializeTest {
      * Test serialization and deserialization when repository is not null.
      */
     @Test
-    public void testValidRepository() throws Exception {
+    public void testValidRepository() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold);
         testInMemoryObject(testFieldValueBytes, REPO);


### PR DESCRIPTION
useful in cases where form-data is utf-8 encoded but
not encoding is not explicitly specified