### PR TITLE
travis: fix buffer overflow in Java_java_net_Inet4AddressImpl_getLoca…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,16 @@
 language: java
 sudo: false
 
-dist: precise
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+# use java 6 compatible maven version
+before_install:
+  - wget https://archive.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip
+  - unzip -qq apache-maven-3.2.5-bin.zip
+  - export M2_HOME=$PWD/apache-maven-3.2.5
+  - export PATH=$M2_HOME/bin:$PATH
 
 jdk:
   - openjdk6


### PR DESCRIPTION
…lHostName of OpenJDK6 and OpenJDK7 when using precise distribution

To fix this use the current (trusty) distribution and manually install openjdk-6-jdk and a java 6 compatible maven version.