### PR TITLE
FileItem.java: remove throwing of Exception

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/FileItem.java
+++ b/src/main/java/org/apache/commons/fileupload/FileItem.java
@@ -144,9 +144,12 @@ public interface FileItem extends FileItemHeadersSupport {
      * @param file The <code>File</code> into which the uploaded item should
      *             be stored.
      *
-     * @throws Exception if an error occurs.
+     * @throws IOException if an I/O exception occurs
+     * @throws FileUploadException if an exception which is unrelated to I/O
+     * occurs
      */
-    void write(File file) throws Exception;
+    void write(File file) throws IOException,
+            FileUploadException;
 
     /**
      * Deletes the underlying storage for a file item, including deleting any

--- a/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload/disk/DiskFileItem.java
@@ -379,10 +379,12 @@ public class DiskFileItem
      * @param file The <code>File</code> into which the uploaded item should
      *             be stored.
      *
-     * @throws Exception if an error occurs.
+     * @throws IOException if an I/O exception occurs
+     * @throws FileUploadException if an exception which is unrelated to I/O
      */
     @Override
-    public void write(File file) throws Exception {
+    public void write(File file) throws IOException,
+            FileUploadException {
         if (isInMemory()) {
             FileOutputStream fout = null;
             try {


### PR DESCRIPTION
Indicating that an interface method throws Exception is overly broad and
hides design issues after inheritance changes.