### PR TITLE
Add missing @Override annotations

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/portlet/PortletRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload/portlet/PortletRequestContext.java
@@ -84,6 +84,7 @@ public class PortletRequestContext implements UploadContext {
      */
     @Override
     @Deprecated
+    @Override
     public int getContentLength() {
         return request.getContentLength();
     }

--- a/src/main/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
@@ -82,6 +82,7 @@ public class ServletRequestContext implements UploadContext {
      */
     @Override
     @Deprecated
+    @Override
     public int getContentLength() {
         return request.getContentLength();
     }

--- a/src/test/java/org/apache/commons/fileupload/MockHttpServletRequest.java
+++ b/src/test/java/org/apache/commons/fileupload/MockHttpServletRequest.java
@@ -269,6 +269,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @Deprecated
+    @Override
     public boolean isRequestedSessionIdFromUrl() {
         return false;
     }
@@ -417,6 +418,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @SuppressWarnings("javadoc") // This is a Servlet 2.4 method
+    @Override
     public String getLocalName() {
         return null;
     }
@@ -434,6 +436,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @SuppressWarnings("javadoc") // This is a Servlet 2.4 method
+    @Override
     public int getLocalPort() {
         return 0;
     }
@@ -443,6 +446,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @SuppressWarnings("javadoc") // This is a Servlet 2.4 method
+    @Override
     public int getRemotePort() {
         return 0;
     }
@@ -468,6 +472,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @SuppressWarnings("javadoc") // This is a Servlet 2.4 method
+    @Override
     public String getLocalAddr() {
         return null;
     }
@@ -532,6 +537,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
      */
     @Override
     @Deprecated
+    @Override
     public String getRealPath(String arg0) {
         return null;
     }


### PR DESCRIPTION
@Override annotations help to detect architectural errors and respond
quicker to method changes. Unclear why the checkstyle configuration
which includes MissingOverride passes the validation if they're missing.