### PR TITLE
Use Apache Commons I/O in tests

### DIFF
--- a/src/test/java/org/apache/commons/fileupload/DefaultFileItemTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DefaultFileItemTest.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
+import org.apache.commons.io.FileUtils;
 
 import org.junit.Test;
 
@@ -140,11 +141,11 @@ public class DefaultFileItemTest {
      * configured threshold, where a specific repository is configured.
      */
     @Test
-    public void testAboveThresholdSpecifiedRepository() {
+    public void testAboveThresholdSpecifiedRepository() throws IOException {
         String tempPath = System.getProperty("java.io.tmpdir");
         String tempDirName = "testAboveThresholdSpecifiedRepository";
         File tempDir = new File(tempPath, tempDirName);
-        tempDir.mkdir();
+        FileUtils.forceMkdir(tempDir);
         doTestAboveThreshold(tempDir);
         assertTrue(tempDir.delete());
     }

--- a/src/test/java/org/apache/commons/fileupload/DiskFileItemSerializeTest.java
+++ b/src/test/java/org/apache/commons/fileupload/DiskFileItemSerializeTest.java
@@ -50,17 +50,15 @@ public class DiskFileItemSerializeTest {
         if (REPO.exists()) {
             FileUtils.deleteDirectory(REPO);
         }
-        assertFalse("Must not exist", REPO.exists());
-        REPO.mkdir();
+        FileUtils.forceMkdir(REPO);
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws IOException {
         for(File file : FileUtils.listFiles(REPO, null, true)) {
             System.out.println("Found leftover file " + file);
         }
-        REPO.delete();
-        assertFalse(REPO + " is not empty", REPO.exists());
+        FileUtils.deleteDirectory(REPO);
     }
 
     /**


### PR DESCRIPTION
Replace File.delete and File.mkdir with Apache Commons I/O's FileUtils
equivalent which throw IOException instead of returning false which
reduces the change to miss unexpected failures and removed assertions
testing the function of Apache Commons I/O which is not our job.