### PR TITLE
(FILEUPLOAD-296) Reuse Buffer: Using the same buffer speeds up the parsing process by …

### DIFF
--- a/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
@@ -332,6 +332,7 @@ public abstract class FileUploadBase {
         try {
             FileItemIterator iter = getItemIterator(ctx);
             FileItemFactory fac = getFileItemFactory();
+            final byte[] buffer = new byte[Streams.DEFAULT_BUFFER_SIZE];
             if (fac == null) {
                 throw new NullPointerException("No FileItemFactory has been set.");
             }
@@ -343,7 +344,7 @@ public abstract class FileUploadBase {
                                                    item.isFormField(), fileName);
                 items.add(fileItem);
                 try {
-                    Streams.copy(item.openStream(), fileItem.getOutputStream(), true);
+                    Streams.copy(item.openStream(), fileItem.getOutputStream(), true, buffer);
                 } catch (FileUploadIOException e) {
                     throw (FileUploadException) e.getCause();
                 } catch (IOException e) {

--- a/src/main/java/org/apache/commons/fileupload2/util/Streams.java
+++ b/src/main/java/org/apache/commons/fileupload2/util/Streams.java
@@ -41,7 +41,7 @@ public final class Streams {
      * Default buffer size for use in
      * {@link #copy(InputStream, OutputStream, boolean)}.
      */
-    private static final int DEFAULT_BUFFER_SIZE = 8192;
+    public static final int DEFAULT_BUFFER_SIZE = 8192;
 
     /**
      * Copies the contents of the given {@link InputStream}


### PR DESCRIPTION
…about 10% (Part-Revert 4ed6e923cb2033272fcb993978d69e325990a5aa)

