### PR TITLE
FILEUPLOAD-302: JUnit Jupiter migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,9 +228,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.5.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/commons/fileupload2/DefaultFileItemTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/DefaultFileItemTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +35,7 @@ import org.apache.commons.fileupload2.FileItem;
 import org.apache.commons.fileupload2.FileItemFactory;
 import org.apache.commons.io.FileUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link org.apache.commons.fileupload2.DefaultFileItem}.

--- a/src/test/java/org/apache/commons/fileupload2/DiskFileItemSerializeTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/DiskFileItemSerializeTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,9 +35,9 @@ import org.apache.commons.fileupload2.FileItem;
 import org.apache.commons.fileupload2.FileItemFactory;
 import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Serialization Unit tests for
@@ -47,7 +48,7 @@ public class DiskFileItemSerializeTest {
     // Use a private repo to catch any files left over by tests
     private static final File REPO = new File(System.getProperty("java.io.tmpdir"), "diskfileitemrepo");
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         if (REPO.exists()) {
             FileUtils.deleteDirectory(REPO);
@@ -55,7 +56,7 @@ public class DiskFileItemSerializeTest {
         FileUtils.forceMkdir(REPO);
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException {
         for(File file : FileUtils.listFiles(REPO, null, true)) {
             System.out.println("Found leftover file " + file);
@@ -80,8 +81,8 @@ public class DiskFileItemSerializeTest {
         FileItem item = createFileItem(testFieldValueBytes, repository);
 
         // Check state is as expected
-        assertTrue("Initial: in memory", item.isInMemory());
-        assertEquals("Initial: size", item.getSize(), testFieldValueBytes.length);
+        assertTrue(item.isInMemory(), "Initial: in memory");
+        assertEquals(item.getSize(), testFieldValueBytes.length, "Initial: size");
         compareBytes("Initial", item.get(), testFieldValueBytes);
         item.delete();
     }
@@ -126,8 +127,8 @@ public class DiskFileItemSerializeTest {
         FileItem item = createFileItem(testFieldValueBytes);
 
         // Check state is as expected
-        assertFalse("Initial: in memory", item.isInMemory());
-        assertEquals("Initial: size", item.getSize(), testFieldValueBytes.length);
+        assertFalse(item.isInMemory(), "Initial: in memory");
+        assertEquals(item.getSize(), testFieldValueBytes.length, "Initial: size");
         compareBytes("Initial", item.get(), testFieldValueBytes);
 
         item.delete();
@@ -146,36 +147,36 @@ public class DiskFileItemSerializeTest {
     /**
      * Test deserialization fails when repository is not valid.
      */
-    @Test(expected=IOException.class)
-    public void testInvalidRepository() throws Exception {
+    @Test
+    public void testInvalidRepository() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold);
         File repository = new File(System.getProperty("java.io.tmpdir"), "file");
         FileItem item = createFileItem(testFieldValueBytes, repository);
-        deserialize(serialize(item));
+        assertThrows(IOException.class, () -> deserialize(serialize(item)));
     }
 
     /**
      * Test deserialization fails when repository contains a null character.
      */
-    @Test(expected=IOException.class)
-    public void testInvalidRepositoryWithNullChar() throws Exception {
+    @Test
+    public void testInvalidRepositoryWithNullChar() {
         // Create the FileItem
         byte[] testFieldValueBytes = createContentBytes(threshold);
         File repository = new File(System.getProperty("java.io.tmpdir"), "\0");
         FileItem item = createFileItem(testFieldValueBytes, repository);
-        deserialize(serialize(item));
+        assertThrows(IOException.class, () -> deserialize(serialize(item)));
     }
 
     /**
      * Compare content bytes.
      */
     private void compareBytes(String text, byte[] origBytes, byte[] newBytes) {
-        assertNotNull("origBytes must not be null", origBytes);
-        assertNotNull("newBytes must not be null", newBytes);
-        assertEquals(text + " byte[] length", origBytes.length, newBytes.length);
+        assertNotNull(origBytes, "origBytes must not be null");
+        assertNotNull(newBytes, "newBytes must not be null");
+        assertEquals(origBytes.length, newBytes.length, text + " byte[] length");
         for (int i = 0; i < origBytes.length; i++) {
-            assertEquals(text + " byte[" + i + "]", origBytes[i], newBytes[i]);
+            assertEquals(origBytes[i], newBytes[i], text + " byte[" + i + "]");
         }
     }
 

--- a/src/test/java/org/apache/commons/fileupload2/DiskFileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/DiskFileUploadTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.util.List;
@@ -27,8 +27,8 @@ import org.apache.commons.fileupload2.DiskFileUpload;
 import org.apache.commons.fileupload2.FileUploadException;
 import org.apache.commons.fileupload2.disk.DiskFileItem;
 import org.apache.commons.fileupload2.impl.InvalidContentTypeException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link DiskFileUpload}. Remove when deprecated class is removed.
@@ -40,7 +40,7 @@ public class DiskFileUploadTest {
 
     private DiskFileUpload upload;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         upload = new DiskFileUpload();
     }

--- a/src/test/java/org/apache/commons/fileupload2/FileItemHeadersTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/FileItemHeadersTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 
 import org.apache.commons.fileupload2.FileItemHeaders;
 import org.apache.commons.fileupload2.util.FileItemHeadersImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link FileItemHeaders} and

--- a/src/test/java/org/apache/commons/fileupload2/FileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/FileUploadTest.java
@@ -16,25 +16,23 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.fileupload2.FileItem;
 import org.apache.commons.fileupload2.FileUpload;
 import org.apache.commons.fileupload2.FileUploadException;
 import org.apache.commons.fileupload2.portlet.PortletFileUploadTest;
 import org.apache.commons.fileupload2.servlet.ServletFileUploadTest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Common tests for implementations of {@link FileUpload}. This is a parameterized test.
@@ -45,27 +43,20 @@ import org.junit.runners.Parameterized.Parameters;
  * @see PortletFileUploadTest
  * @since 1.4
  */
-@RunWith(Parameterized.class)
 public class FileUploadTest {
 
     /**
      * @return {@link FileUpload} classes under test.
      */
-    @Parameters(name="{0}")
-    public static Iterable<? extends Object> data() {
-        return Util.fileUploadImplementations();
+    public static Stream<FileUpload> data() {
+        return Util.fileUploadImplementations().stream();
     }
-
-    /**
-     * Current parameterized FileUpload.
-     */
-    @Parameter
-    public FileUpload upload;
 
     // --- Test methods common to all implementations of a FileUpload
 
-    @Test
-    public void testFileUpload()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFileUpload(FileUpload upload)
             throws IOException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload(upload,
                                                "-----1234\r\n" +
@@ -112,8 +103,9 @@ public class FileUploadTest {
         assertEquals("value2", multi1.getString());
     }
 
-    @Test
-    public void testFilenameCaseSensitivity()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFilenameCaseSensitivity(FileUpload upload)
             throws IOException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload(upload,
                                                "-----1234\r\n" +
@@ -133,8 +125,9 @@ public class FileUploadTest {
     /**
      * This is what the browser does if you submit the form without choosing a file.
      */
-    @Test
-    public void testEmptyFile()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testEmptyFile(FileUpload upload)
             throws UnsupportedEncodingException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload (upload,
                                                 "-----1234\r\n" +
@@ -155,8 +148,9 @@ public class FileUploadTest {
      * return is missing on any boundary line immediately preceding
      * an input with type=image. (type=submit does not have the bug.)
      */
-    @Test
-    public void testIE5MacBug()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testIE5MacBug(FileUpload upload)
             throws UnsupportedEncodingException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload(upload,
                                                "-----1234\r\n" +
@@ -203,8 +197,9 @@ public class FileUploadTest {
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/FILEUPLOAD-62">FILEUPLOAD-62</a>
      */
-    @Test
-    public void testFILEUPLOAD62() throws Exception {
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFILEUPLOAD62(FileUpload upload) throws Exception {
         final String contentType = "multipart/form-data; boundary=AaB03x";
         final String request =
             "--AaB03x\r\n" +
@@ -247,8 +242,9 @@ public class FileUploadTest {
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/FILEUPLOAD-111">FILEUPLOAD-111</a>
      */
-    @Test
-    public void testFoldedHeaders()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFoldedHeaders(FileUpload upload)
             throws IOException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload(upload, "-----1234\r\n" +
                 "Content-Disposition: form-data; name=\"file\"; filename=\"foo.tab\"\r\n" +
@@ -299,8 +295,9 @@ public class FileUploadTest {
     /**
      * Test case for <a href="https://issues.apache.org/jira/browse/FILEUPLOAD-130">
      */
-    @Test
-    public void testFileUpload130()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testFileUpload130(FileUpload upload)
             throws Exception {
         final String[] headerNames = new String[]
         {
@@ -354,8 +351,9 @@ public class FileUploadTest {
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/FILEUPLOAD-239">FILEUPLOAD-239</a>
      */
-    @Test
-    public void testContentTypeAttachment()
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testContentTypeAttachment(FileUpload upload)
             throws IOException, FileUploadException {
         List<FileItem> fileItems = Util.parseUpload(upload,
                 "-----1234\r\n" +

--- a/src/test/java/org/apache/commons/fileupload2/MultipartStreamTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/MultipartStreamTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.commons.fileupload2.MultipartStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests {@link org.apache.commons.fileupload2.MultipartStream}.
@@ -47,18 +48,19 @@ public class MultipartStreamTest {
         assertNotNull(ms);
     }
 
-    @Test(expected=IllegalArgumentException.class)
-    public void testSmallBuffer() throws Exception {
+    @Test
+    public void testSmallBuffer() {
         final String strData = "foobar";
         final byte[] contents = strData.getBytes();
         InputStream input = new ByteArrayInputStream(contents);
         byte[] boundary = BOUNDARY_TEXT.getBytes();
         int iBufSize = 1;
-        new MultipartStream(
-                input,
-                boundary,
-                iBufSize,
-                new MultipartStream.ProgressNotifier(null, contents.length));
+        assertThrows(IllegalArgumentException.class,
+                () -> new MultipartStream(
+                        input,
+                        boundary,
+                        iBufSize,
+                        new MultipartStream.ProgressNotifier(null, contents.length)));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/fileupload2/ParameterParserTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/ParameterParserTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 
 import org.apache.commons.fileupload2.ParameterParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for {@link ParameterParser}.

--- a/src/test/java/org/apache/commons/fileupload2/ProgressListenerTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/ProgressListenerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,7 +29,7 @@ import org.apache.commons.fileupload2.FileItemStream;
 import org.apache.commons.fileupload2.FileUploadException;
 import org.apache.commons.fileupload2.ProgressListener;
 import org.apache.commons.fileupload2.servlet.ServletFileUpload;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link ProgressListener}.

--- a/src/test/java/org/apache/commons/fileupload2/SizesTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/SizesTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -39,7 +39,7 @@ import org.apache.commons.fileupload2.impl.FileUploadIOException;
 import org.apache.commons.fileupload2.impl.SizeLimitExceededException;
 import org.apache.commons.fileupload2.servlet.ServletFileUpload;
 import org.apache.commons.fileupload2.util.Streams;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for items with varying sizes.

--- a/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.fileupload2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,7 +41,7 @@ import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload2.impl.IOFileUploadException;
 import org.apache.commons.fileupload2.servlet.ServletFileUpload;
 import org.apache.commons.fileupload2.servlet.ServletRequestContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for items with varying sizes.

--- a/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.fileupload2;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterInputStream;
@@ -37,17 +41,17 @@ import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload2.impl.IOFileUploadException;
 import org.apache.commons.fileupload2.servlet.ServletFileUpload;
 import org.apache.commons.fileupload2.servlet.ServletRequestContext;
-
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit test for items with varying sizes.
  */
-public class StreamingTest extends TestCase {
+public class StreamingTest {
 
     /**
      * Tests a file upload with varying file sizes.
      */
+    @Test
     public void testFileUpload()
             throws IOException, FileUploadException {
         byte[] request = newRequest();
@@ -74,6 +78,7 @@ public class StreamingTest extends TestCase {
      * Tests, whether an invalid request throws a proper
      * exception.
      */
+    @Test
     public void testFileUploadException()
             throws IOException, FileUploadException {
         byte[] request = newRequest();
@@ -90,6 +95,7 @@ public class StreamingTest extends TestCase {
     /**
      * Tests, whether an IOException is properly delegated.
      */
+    @Test
     public void testIOException()
             throws IOException {
         byte[] request = newRequest();
@@ -127,6 +133,7 @@ public class StreamingTest extends TestCase {
     /**
      * Test for FILEUPLOAD-135
      */
+    @Test
     public void testFILEUPLOAD135()
             throws IOException, FileUploadException {
         byte[] request = newShortRequest();
@@ -232,6 +239,7 @@ public class StreamingTest extends TestCase {
     /**
      * Tests, whether an {@link InvalidFileNameException} is thrown.
      */
+    @Test
     public void testInvalidFileNameException() throws Exception {
         final String fileName = "foo.exe\u0000.png";
         final String request =

--- a/src/test/java/org/apache/commons/fileupload2/portlet/PortletFileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/portlet/PortletFileUploadTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.commons.fileupload2.portlet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -29,8 +29,8 @@ import org.apache.commons.fileupload2.FileItem;
 import org.apache.commons.fileupload2.FileUploadTest;
 import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload2.portlet.PortletFileUpload;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link PortletFileUpload}.
@@ -42,7 +42,7 @@ public class PortletFileUploadTest {
 
     private PortletFileUpload upload;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         upload = new PortletFileUpload(new DiskFileItemFactory());
     }

--- a/src/test/java/org/apache/commons/fileupload2/servlet/ServletFileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/servlet/ServletFileUploadTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.commons.fileupload2.servlet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -30,7 +30,7 @@ import org.apache.commons.fileupload2.FileUploadTest;
 import org.apache.commons.fileupload2.MockHttpServletRequest;
 import org.apache.commons.fileupload2.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload2.servlet.ServletFileUpload;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link ServletFileUpload}.
@@ -100,6 +100,6 @@ public class ServletFileUploadTest {
         ServletFileUpload upload = new ServletFileUpload(fileItemFactory);
         List<FileItem> fileItems = upload.parseRequest(request);
         FileItem fileItem = fileItems.get(0);
-        assertTrue(fileItem.getString(), fileItem.getString().contains("coñteñt"));
+        assertTrue(fileItem.getString().contains("coñteñt"), fileItem.getString());
     }
 }

--- a/src/test/java/org/apache/commons/fileupload2/util/mime/Base64DecoderTestCase.java
+++ b/src/test/java/org/apache/commons/fileupload2/util/mime/Base64DecoderTestCase.java
@@ -16,16 +16,17 @@
  */
 package org.apache.commons.fileupload2.util.mime;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import org.apache.commons.fileupload2.util.mime.Base64Decoder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 1.3
@@ -77,10 +78,10 @@ public final class Base64DecoderTestCase {
         assertEncoded("Hello World", "S?G!V%sbG 8g\rV\t\n29ybGQ*=");
     }
 
-    @Test(expected = IOException.class)
-    public void truncatedString() throws Exception {
+    @Test
+    public void truncatedString() {
         final byte[] x = new byte[]{'n'};
-        Base64Decoder.decode(x, new ByteArrayOutputStream());
+        assertThrows(IOException.class, () -> Base64Decoder.decode(x, new ByteArrayOutputStream()));
     }
 
     @Test
@@ -157,7 +158,7 @@ public final class Base64DecoderTestCase {
             fail("Expected IOException");
         } catch (IOException e) {
             String em = e.getMessage();
-            assertTrue("Expected to find " + messageText + " in '" + em + "'",em.contains(messageText));
+            assertTrue(em.contains(messageText), "Expected to find " + messageText + " in '" + em + "'");
         }
     }
 

--- a/src/test/java/org/apache/commons/fileupload2/util/mime/MimeUtilityTestCase.java
+++ b/src/test/java/org/apache/commons/fileupload2/util/mime/MimeUtilityTestCase.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.fileupload2.util.mime;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.UnsupportedEncodingException;
 
 import org.apache.commons.fileupload2.util.mime.MimeUtility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Use the online <a href="http://dogmamix.com/MimeHeadersDecoder/">MimeHeadersDecoder</a>
@@ -62,8 +63,8 @@ public final class MimeUtilityTestCase {
         assertEquals(expected, MimeUtility.decodeText(encoded));
     }
 
-    @Test(expected=UnsupportedEncodingException.class)
-    public void decodeInvalidEncoding() throws Exception {
-        MimeUtility.decodeText("=?invalid?B?xyz-?=");
+    @Test
+    public void decodeInvalidEncoding() {
+        assertThrows(UnsupportedEncodingException.class, () -> MimeUtility.decodeText("=?invalid?B?xyz-?="));
     }
 }

--- a/src/test/java/org/apache/commons/fileupload2/util/mime/QuotedPrintableDecoderTestCase.java
+++ b/src/test/java/org/apache/commons/fileupload2/util/mime/QuotedPrintableDecoderTestCase.java
@@ -16,16 +16,17 @@
  */
 package org.apache.commons.fileupload2.util.mime;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import org.apache.commons.fileupload2.util.mime.QuotedPrintableDecoder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @since 1.3
@@ -66,9 +67,9 @@ public final class QuotedPrintableDecoderTestCase {
         assertEncoded("=\r\n", "=3d=0d=0a");
     }
 
-    @Test(expected = IOException.class)
-    public void invalidCharDecode() throws Exception {
-        assertEncoded("=\r\n", "=3D=XD=XA");
+    @Test
+    public void invalidCharDecode() {
+        assertThrows(IOException.class, () -> assertEncoded("=\r\n", "=3D=XD=XA"));
     }
 
     /**
@@ -117,7 +118,7 @@ public final class QuotedPrintableDecoderTestCase {
             fail("Expected IOException");
         } catch (IOException e) {
             String em = e.getMessage();
-            assertTrue("Expected to find " + messageText + " in '" + em + "'",em.contains(messageText));
+            assertTrue(em.contains(messageText), "Expected to find " + messageText + " in '" + em + "'");
         }
     }
 


### PR DESCRIPTION
This PR upgrades the project's testing framework from JUnit 4.12 to the modern JUnit Jupiter 5.5.2.

Since JUnit 5 Jupiter is not backwards compatible to JUnit 4.x (or even JUnit Vintage), this PR is a bit large, even though most of the changes are merely cosmetic (such as changing the argument order,
see details below). In order to make the reviewer's task as easy as possible, this PR does not presume to use JUnit Jupiter's best practices and all its new functionality, but only to migrate the
existing tests with as little change as possible. Following PRs may want to improve the tests by using some of JUnit Jupiter's new features.

This PR includes the following changes:

1. Maven dependency changes:
     1. `junit:junit` was replaced with `org.junit.jupiter:junit-jupiter`.

2. Annotations:
     1. `org.junit.jupiter.api.Test` was used as a drop in replacement for `org.juit.Test` without arguments. See 3.i. for handling of `@Test` annotations with an `expected` argument.
     1. The missing `@Test` annotations were added to `StreamingTest`'s test method. JUnit 4 allows omitting them, while JUnit Jupiter does not.
     1. `org.junit.jupiter.api.BeforeEach` was used as an drop in replacement for `org.junit.Before`.
     1. `org.junit.jupiter.api.AfterEach` was used as an drop in replacement for `org.junit.After`.

3. Assertions:
     1. `org.junit.jupiter.api.Assertions`' methods were used as drop in replacements for `org.junit.Assert`'s methods with the same name in the simple case of an assertion without a message. In the case of an assertion with a message, `org.junit.jupiter.api.Assertions`' methods were used, but the argument order was changed - `Assert`'s methods take the message as the first argument, while `Assertions`' methods take the message as the last argument.
     1. `org.junit.jupiter.api.Assertions`' methods were used as drop in replacements for `junit.framework.TestCase`'s methods with the same name in the simple case of an assertion without a message.
     1. `org.junit.jupiter.api.Assertions#assertThrows` was used to assert that a specific exception was throws instead of an `org.junit.Test` annotation with an `expected` argument. As a side bonus, this change makes the tests slightly stricter, as now they can assert the exception was thrown from a specific line and prevent false positives where the test's "set-up" code accidentally threw that exception.


4. Parameterized tests:
     1. `FileUploadTest` was rewritten with `@ParameterizedTest` and `@MethodSource` in order to gain an equivalent functionality of JUnit 4's `Parameterized` runner.