### PR TITLE
 Exclude DLS_DEAD_LOCAL_STORE  what i think it's a false positive.

### DIFF
--- a/spotbugs-exclude-filter.xml
+++ b/spotbugs-exclude-filter.xml
@@ -50,6 +50,11 @@
         <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
     </Match>
     <Match>
+        <Class name="org.apache.commons.fileupload2.disk.DiskFileItem" />
+        <Method name="getString" />
+        <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+    </Match>
+    <Match>
         <Class name="org.apache.commons.fileupload2.jaksrvlt.JakSrvltFileUpload" />
         <Bug pattern="NM_WRONG_PACKAGE" />
     </Match>


### PR DESCRIPTION
When I running 
`mvn -V package --file pom.xml --no-transfer-progress spotbugs:check` i'm getting DLS_DEAD_LOCAL_STORE error. Which is --> DLS: Dead store to local variable (DLS_DEAD_LOCAL_STORE)

This instruction assigns a value to a local variable, but the value is not read or used in any subsequent instruction. Often, this indicates an error, because the value computed is never used.

Note that Sun's javac compiler often generates dead stores for final local variables. Because FindBugs is a bytecode-based tool, there is no easy way to eliminate these false positives.

In order to avoid break the compilation while I analizy all the errors, we ignore this error


