### PR TITLE
FILEUPLOAD-327 - Solve SpotBug warning/errors

### DIFF
--- a/spotbugs-exclude-filter.xml
+++ b/spotbugs-exclude-filter.xml
@@ -33,17 +33,8 @@
         <Bug pattern="MS_PKGPROTECT" />
     </Match>
     <Match>
-        <Class name="org.apache.commons.fileupload2.ParameterParser" />
-        <Method name="parse" />
-        <Bug pattern="EI_EXPOSE_REP2" />
-    </Match>
-    <Match>
         <Class name="org.apache.commons.fileupload2.disk.DiskFileItem" />
         <Bug pattern="DM_DEFAULT_ENCODING" />
-    </Match>
-    <Match>
-        <Class name="org.apache.commons.fileupload2.disk.DiskFileItem" />
-        <Bug pattern="EI_EXPOSE_REP" />
     </Match>
     <Match>
         <Class name="org.apache.commons.fileupload2.disk.DiskFileItem" />

--- a/src/main/java/org/apache/commons/fileupload2/ParameterParser.java
+++ b/src/main/java/org/apache/commons/fileupload2/ParameterParser.java
@@ -299,7 +299,7 @@ public class ParameterParser {
             return new HashMap<>();
         }
         final HashMap<String, String> params = new HashMap<>();
-        this.chars = charArray;
+        this.chars = charArray.clone();
         this.pos = offset;
         this.len = length;
 

--- a/src/main/java/org/apache/commons/fileupload2/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload2/disk/DiskFileItem.java
@@ -305,7 +305,7 @@ public class DiskFileItem
             if (cachedContent == null && dfos != null) {
                 cachedContent = dfos.getData();
             }
-            return cachedContent;
+            return cachedContent != null ? cachedContent.clone() : new byte[0];
         }
 
         byte[] fileData = new byte[(int) getSize()];
@@ -347,16 +347,15 @@ public class DiskFileItem
      */
     @Override
     public String getString() {
-        byte[] rawdata = new byte[0];
         try {
-            rawdata = get();
+            byte[] rawData = get();
             String charset = getCharSet();
             if (charset == null) {
                 charset = defaultCharset;
             }
-            return new String(rawdata, charset);
+            return new String(rawData, charset);
         } catch (final IOException e) {
-            return new String(rawdata);
+            return new String(new byte[0]);
         }
     }
 


### PR DESCRIPTION
Solve:

- MS_PKGPROTECT -->MS: Field should be package protected (MS_PKGPROTECT)

- EI_EXPOSE_REP2 --> EI2: May expose internal representation by incorporating reference to mutable object (EI_EXPOSE_REP2)

- EI_EXPOSE_REP -->  EI: May expose internal representation by returning reference to mutable object (EI_EXPOSE_REP)



`INFO] <<< spotbugs-maven-plugin:4.2.3:check (default-cli) < :spotbugs @ commons-fileupload2 <<<
[INFO]
[INFO]
[INFO] --- spotbugs-maven-plugin:4.2.3:check (default-cli) @ commons-fileupload2 ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.653 s
[INFO] Finished at: 2021-05-01T19:36:26+02:00`