### PR TITLE
Replace indexOf() with contains()

### DIFF
--- a/src/main/java/org/apache/commons/fileupload2/util/mime/MimeUtility.java
+++ b/src/main/java/org/apache/commons/fileupload2/util/mime/MimeUtility.java
@@ -95,7 +95,7 @@ public final class MimeUtility {
     public static String decodeText(final String text) throws UnsupportedEncodingException {
         // if the text contains any encoded tokens, those tokens will be marked with "=?".  If the
         // source string doesn't contain that sequent, no decoding is required.
-        if (text.indexOf(ENCODED_TOKEN_MARKER) < 0) {
+        if (!text.contains(ENCODED_TOKEN_MARKER)) {
             return text;
         }
 

--- a/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/StreamingTest.java
@@ -265,7 +265,7 @@ public class StreamingTest {
         } catch (final InvalidFileNameException e) {
             assertEquals(fileName, e.getName());
             assertEquals(-1, e.getMessage().indexOf(fileName));
-            assertTrue(e.getMessage().indexOf("foo.exe\\0.png") != -1);
+            assertTrue(e.getMessage().contains("foo.exe\\0.png"));
         }
 
         try {
@@ -274,7 +274,7 @@ public class StreamingTest {
         } catch (final InvalidFileNameException e) {
             assertEquals(fileName, e.getName());
             assertEquals(-1, e.getMessage().indexOf(fileName));
-            assertTrue(e.getMessage().indexOf("foo.exe\\0.png") != -1);
+            assertTrue(e.getMessage().contains("foo.exe\\0.png"));
         }
     }
 


### PR DESCRIPTION
jsparrow --> 

'Most checks against an indexOf value compare it with -1 because 0 is a valid index. Any checks which look for values >0 ignore the first element, which is likely a bug. If the intent is merely to check inclusion of a value in a String or a List, the contains method is better suited to express this intent. Clearer intent means better readability.'