### PR TITLE
Remove unnecessary boxing

### DIFF
--- a/src/main/java/org/apache/commons/fileupload2/MultipartStream.java
+++ b/src/main/java/org/apache/commons/fileupload2/MultipartStream.java
@@ -572,7 +572,7 @@ public class MultipartStream {
             if (++size > HEADER_PART_SIZE_MAX) {
                 throw new MalformedStreamException(
                         format("Header section has more than %s bytes (maybe it is not properly terminated)",
-                               Integer.valueOf(HEADER_PART_SIZE_MAX)));
+                                HEADER_PART_SIZE_MAX));
             }
             if (b == HEADER_SEPARATOR[i]) {
                 i++;

--- a/src/main/java/org/apache/commons/fileupload2/disk/DiskFileItem.java
+++ b/src/main/java/org/apache/commons/fileupload2/disk/DiskFileItem.java
@@ -599,8 +599,8 @@ public class DiskFileItem
     @Override
     public String toString() {
         return format("name=%s, StoreLocation=%s, size=%s bytes, isFormField=%s, FieldName=%s",
-                      getName(), getStoreLocation(), Long.valueOf(getSize()),
-                      Boolean.valueOf(isFormField()), getFieldName());
+                      getName(), getStoreLocation(), getSize(),
+                isFormField(), getFieldName());
     }
 
     /**

--- a/src/main/java/org/apache/commons/fileupload2/impl/FileItemIteratorImpl.java
+++ b/src/main/java/org/apache/commons/fileupload2/impl/FileItemIteratorImpl.java
@@ -168,7 +168,7 @@ public class FileItemIteratorImpl implements FileItemIterator {
             if (requestSize != -1 && requestSize > sizeMax) {
                 throw new SizeLimitExceededException(
                     format("the request was rejected because its size (%s) exceeds the configured maximum (%s)",
-                            Long.valueOf(requestSize), Long.valueOf(sizeMax)),
+                            requestSize, sizeMax),
                            requestSize, sizeMax);
             }
             // N.B. this is eventually closed in MultipartStream processing
@@ -178,7 +178,7 @@ public class FileItemIteratorImpl implements FileItemIterator {
                         throws IOException {
                     final FileUploadException ex = new SizeLimitExceededException(
                     format("the request was rejected because its size (%s) exceeds the configured maximum (%s)",
-                            Long.valueOf(pCount), Long.valueOf(pSizeMax)),
+                            pCount, pSizeMax),
                            pCount, pSizeMax);
                     throw new FileUploadIOException(ex);
                 }

--- a/src/main/java/org/apache/commons/fileupload2/impl/FileItemStreamImpl.java
+++ b/src/main/java/org/apache/commons/fileupload2/impl/FileItemStreamImpl.java
@@ -101,7 +101,7 @@ public class FileItemStreamImpl implements FileItemStream {
             final FileSizeLimitExceededException e =
                     new FileSizeLimitExceededException(
                             format("The field %s exceeds its maximum permitted size of %s bytes.",
-                                    fieldName, Long.valueOf(fileSizeMax)),
+                                    fieldName, fileSizeMax),
                             pContentLength, fileSizeMax);
             e.setFileName(pName);
             e.setFieldName(pFieldName);
@@ -119,7 +119,7 @@ public class FileItemStreamImpl implements FileItemStream {
                     final FileSizeLimitExceededException e =
                         new FileSizeLimitExceededException(
                             format("The field %s exceeds its maximum permitted size of %s bytes.",
-                                   fieldName, Long.valueOf(pSizeMax)),
+                                   fieldName, pSizeMax),
                             pCount, pSizeMax);
                     e.setFieldName(fieldName);
                     e.setFileName(name);

--- a/src/main/java/org/apache/commons/fileupload2/jaksrvlt/JakSrvltRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload2/jaksrvlt/JakSrvltRequestContext.java
@@ -123,7 +123,7 @@ public class JakSrvltRequestContext implements UploadContext {
     @Override
     public String toString() {
         return format("ContentLength=%s, ContentType=%s",
-                Long.valueOf(this.contentLength()),
+                this.contentLength(),
                 this.getContentType());
     }
 

--- a/src/main/java/org/apache/commons/fileupload2/portlet/PortletRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload2/portlet/PortletRequestContext.java
@@ -125,7 +125,7 @@ public class PortletRequestContext implements UploadContext {
     @Override
     public String toString() {
         return format("ContentLength=%s, ContentType=%s",
-                      Long.valueOf(this.contentLength()),
+                this.contentLength(),
                       this.getContentType());
     }
 

--- a/src/main/java/org/apache/commons/fileupload2/servlet/ServletRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload2/servlet/ServletRequestContext.java
@@ -123,7 +123,7 @@ public class ServletRequestContext implements UploadContext {
     @Override
     public String toString() {
         return format("ContentLength=%s, ContentType=%s",
-                Long.valueOf(this.contentLength()),
+                this.contentLength(),
                 this.getContentType());
     }
 


### PR DESCRIPTION
Explicit manual boxing is unnecessary as for Java 5 and later, and can safely be removed.