### PR TITLE
Add a new limit for the number of files uploaded per request

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -55,6 +55,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action                        dev="ggregory" type="add" due-to="Gary Gregory">Add github/codeql-action from #144.</action>
       <action                        dev="jochen" type="add">Add the package org.apache.fileupload2.jaksrvlt, for compliance with Jakarta Servlet API 5.0.</action>
       <action                        dev="jochen" type="add">Making FileUploadException a subclass of IOException. (Mibor API simplification.)</action>
+      <action                        dev="markt" type="add">Add a configurable limit (disabled by default) for the number of files to upload per request.</action>
       <!-- UPDATE -->
       <action                        dev="ggregory" type="update" due-to="Dependabot, Gary Gregory">Bump actions/cache from 2.1.6 to 3.0.8 #128, #140.</action>
       <action                        dev="ggregory" type="update" due-to="Dependabot, Gary Gregory">Bump actions/checkout from 2.3.4 to 3.0.2 #125.</action>

--- a/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.fileupload2.impl.FileItemIteratorImpl;
+import org.apache.commons.fileupload2.pub.FileCountLimitExceededException;
 import org.apache.commons.fileupload2.pub.FileUploadIOException;
 import org.apache.commons.fileupload2.pub.IOFileUploadException;
 import org.apache.commons.fileupload2.util.FileItemHeadersImpl;
@@ -141,6 +142,12 @@ public abstract class FileUploadBase {
     private long fileSizeMax = -1;
 
     /**
+     * The maximum permitted number of files that may be uploaded in a single
+     * request. A value of -1 indicates no maximum.
+     */
+    private long fileCountMax = -1;
+
+    /**
      * The content encoding to use when reading part headers.
      */
     private String headerEncoding;
@@ -217,6 +224,24 @@ public abstract class FileUploadBase {
     }
 
     /**
+     * Returns the maximum number of files allowed in a single request.
+     *
+     * @return The maximum number of files allowed in a single request.
+     */
+    public long getFileCountMax() {
+        return fileCountMax;
+    }
+
+    /**
+     * Sets the maximum number of files allowed per request.
+     *
+     * @param fileCountMax The new limit. {@code -1} means no limit.
+     */
+    public void setFileCountMax(final long fileCountMax) {
+        this.fileCountMax = fileCountMax;
+    }
+
+    /**
      * Retrieves the character encoding used when reading the headers of an
      * individual part. When not specified, or {@code null}, the request
      * encoding is used. If that is also not specified, or {@code null},
@@ -290,6 +315,10 @@ public abstract class FileUploadBase {
                     "No FileItemFactory has been set.");
             final byte[] buffer = new byte[Streams.DEFAULT_BUFFER_SIZE];
             while (iter.hasNext()) {
+                if (items.size() == fileCountMax) {
+                    // The next item will exceed the limit.
+                    throw new FileCountLimitExceededException(ATTACHMENT, getFileCountMax());
+                }
                 final FileItemStream item = iter.next();
                 // Don't use getName() here to prevent an InvalidFileNameException.
                 final String fileName = item.getName();

--- a/src/main/java/org/apache/commons/fileupload2/pub/FileCountLimitExceededException.java
+++ b/src/main/java/org/apache/commons/fileupload2/pub/FileCountLimitExceededException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.fileupload2.pub;
+
+import org.apache.commons.fileupload2.FileUploadException;
+
+/**
+ * This exception is thrown if a request contains more files than the specified
+ * limit.
+ */
+public class FileCountLimitExceededException extends FileUploadException {
+
+    private static final long serialVersionUID = 2408766352570556046L;
+
+    /**
+     * The limit that was exceeded.
+     */
+    private final long limit;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message The detail message
+     * @param limit The limit that was exceeded
+     */
+    public FileCountLimitExceededException(final String message, final long limit) {
+        super(message);
+        this.limit = limit;
+    }
+
+    /**
+     * Retrieves the limit that was exceeded.
+     *
+     * @return The limit that was exceeded by the request
+     */
+    public long getLimit() {
+        return limit;
+    }
+}


### PR DESCRIPTION
Tomcat current has a limit for request parameters. Multi-part uploads processed via Tomcat's fork of Commons FileUpload are not included in that limit which is inconsistent. I have a patch for Tomcat that fixes that but I think the fix would be more generally useful. Therefore I am proposing this change for Commons FileUpload.

While I'd be delighted if this was accepted as is, I'm happy to make changes if required.