### PR TITLE
Adding capability to take max upload size per request.

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
+++ b/src/main/java/org/apache/commons/fileupload/servlet/ServletRequestContext.java
@@ -127,4 +127,13 @@ public class ServletRequestContext implements UploadContext {
                 this.getContentType());
     }
 
+    /**
+     * Gets underlying HttpServletRequest, this method can be used in subclasses of @{@link FileUploadBase}
+     * while adding support for max upload size per request.
+     * @return
+     */
+    public HttpServletRequest getRequest(){
+        return this.request;
+    }
+
 }


### PR DESCRIPTION
As of now FileUploadBase has sizeMax which is global for all uploads, in many cases it is required to calculate this limit based on request.

https://stackoverflow.com/questions/16585866/changing-file-size-limit-maxuploadsize-depending-on-the-controller