### PR TITLE
FileCountMax limit incorrectly count both simple form fields and files

### DIFF
--- a/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload2/FileUploadBase.java
@@ -308,6 +308,7 @@ public abstract class FileUploadBase {
     public List<FileItem> parseRequest(final RequestContext ctx)
             throws FileUploadException {
         final List<FileItem> items = new ArrayList<>();
+        int fileCount = 0;
         boolean successful = false;
         try {
             final FileItemIterator iter = getItemIterator(ctx);
@@ -315,7 +316,7 @@ public abstract class FileUploadBase {
                     "No FileItemFactory has been set.");
             final byte[] buffer = new byte[Streams.DEFAULT_BUFFER_SIZE];
             while (iter.hasNext()) {
-                if (items.size() == fileCountMax) {
+                if (fileCount == fileCountMax) {
                     // The next item will exceed the limit.
                     throw new FileCountLimitExceededException(ATTACHMENT, getFileCountMax());
                 }
@@ -333,6 +334,10 @@ public abstract class FileUploadBase {
                     throw new IOFileUploadException(format("Processing of %s request failed. %s",
                                                            MULTIPART_FORM_DATA, e.getMessage()), e);
                 }
+                if (!fileItem.isFormField()) {
+                  fileCount++;
+                }
+
                 final FileItemHeaders fih = item.getHeaders();
                 fileItem.setHeaders(fih);
             }

--- a/src/test/java/org/apache/commons/fileupload2/SizesTest.java
+++ b/src/test/java/org/apache/commons/fileupload2/SizesTest.java
@@ -286,7 +286,7 @@ public class SizesTest {
         }
     }
 
-    /** Checks, whether the maxSize works.
+    /** Checks, whether the fileCountMax works.
      */
     @Test
     public void testCountMaxLimit()


### PR DESCRIPTION
The set FileCountMax limit introduced in 1.5 incorrectly count both simple form fields and files

As described in the javadoc, the setFileCountMax is "the maximum number of files allowed per request."

Bug : current implementation throws an exception when the number of fields reaches the limit, thus including both file and simple field.

Expected behavior :
Exception should only be thrown when number of *file* reaches the limit. To prevent DoS in a practical manner, only files should be limited, as number of simple form fields can be very large and should not be limited.

Fix :
1. Add unittest in SizesTest to check expected behavior
2. Change implementation in FileUploadBase to count and check only real file items, not simple form field