### PR TITLE
Question about ETA for apache-commons 2.0

### DIFF
--- a/QUESTION
+++ b/QUESTION
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
Hello,

We are waiting for apache-commons 2.0 to upgrade our service to Spring 6 and Spring Boot 3 (which use `jakarta` classes).
I see that the work for supporting both `javax` and `jakarta` is going on in the master branch. 

What is the ETA for releasing new versions of apache-commons from master?

PS Sorry for the fake pull request, but I didn't find other ways to ask community a question 