### PR TITLE
Upgrade of `commons-fileupload2-jakarta` to support Jakarta Servlet API 6.x

### DIFF
--- a/commons-fileupload2-jakarta/pom.xml
+++ b/commons-fileupload2-jakarta/pom.xml
@@ -26,6 +26,7 @@
   </parent>
 
   <artifactId>commons-fileupload2-jakarta</artifactId>
+  <version>3.0.0-SNAPSHOT</version>
 
   <name>Apache Commons FileUpload Jakarta</name>
   <description>
@@ -34,8 +35,21 @@
   </description>
 
   <properties>
-	<commons.parent.dir>${basedir}/..</commons.parent.dir>
+    <commons.parent.dir>${basedir}/..</commons.parent.dir>
 	<commons.module.name>org.apache.commons.fileupload2.jakarta</commons.module.name>
+
+	<!-- Override properties for the OSGi maven-bundle-plugin to generate proper manifest -->
+    <commons.osgi.symbolicName>org.apache.commons.${commons.packageId}</commons.osgi.symbolicName>
+    <commons.osgi.export>org.apache.commons.*;version=${project.version}</commons.osgi.export>
+    <commons.osgi.export>*;version=${project.version}</commons.osgi.export>
+    <commons.osgi.import>*</commons.osgi.import>
+    <commons.osgi.dynamicImport />
+    <commons.osgi.private />
+    <!-- setting to true has a side effect of removing version information from 'Import-Package' manifest headers, which is incorrect -->
+    <commons.osgi.excludeDependencies>false</commons.osgi.excludeDependencies>
+
+    <!-- Override link to Jakarta EE -->
+    <commons.javadoc.javaee.link>https://jakarta.ee/specifications/platform/10/apidocs/</commons.javadoc.javaee.link>
   </properties>
 
   <dependencies>
@@ -63,8 +77,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <!-- Version 6.0.0 requires Java 11 -->
-      <version>5.0.0</version>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -104,6 +117,23 @@
         </includes>
       </testResource>
     </testResources>
+    
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <excludeDependencies>${commons.osgi.excludeDependencies}</excludeDependencies>
+          <instructions>
+            <Require-Capability>
+                osgi.contract;filter:="(&amp;(osgi.contract=JakartaServlet)(version=6.0))"
+            </Require-Capability>
+            <_noimportjava>true</_noimportjava>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+        
   </build>
   
 </project>

--- a/commons-fileupload2-jakarta/src/test/java/org/apache/commons/fileupload2/jakarta/JakartaMockHttpServletRequest.java
+++ b/commons-fileupload2-jakarta/src/test/java/org/apache/commons/fileupload2/jakarta/JakartaMockHttpServletRequest.java
@@ -34,6 +34,7 @@ import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -395,16 +396,6 @@ public class JakartaMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * @see ServletRequest#getRealPath(String)
-     * @deprecated
-     */
-    @Override
-    @Deprecated
-    public String getRealPath(final String arg0) {
-        return null;
-    }
-
-    /**
      * @see ServletRequest#getRemoteAddr()
      */
     @Override
@@ -549,16 +540,6 @@ public class JakartaMockHttpServletRequest implements HttpServletRequest {
     }
 
     /**
-     * @see HttpServletRequest#isRequestedSessionIdFromUrl()
-     * @deprecated
-     */
-    @Override
-    @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
-        return false;
-    }
-
-    /**
      * @see HttpServletRequest#isRequestedSessionIdFromURL()
      */
     @Override
@@ -636,4 +617,18 @@ public class JakartaMockHttpServletRequest implements HttpServletRequest {
         return null;
     }
 
+    @Override
+    public String getRequestId() {
+        return null;
+    }
+
+    @Override
+    public String getProtocolRequestId() {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection() {
+        return null;
+    }
 }

--- a/commons-fileupload2-jakarta/src/test/java/org/apache/commons/fileupload2/jakarta/JakartaMockServletHttpRequest.java
+++ b/commons-fileupload2-jakarta/src/test/java/org/apache/commons/fileupload2/jakarta/JakartaMockServletHttpRequest.java
@@ -33,6 +33,7 @@ import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ReadListener;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -393,11 +394,6 @@ public class JakartaMockServletHttpRequest implements HttpServletRequest {
         return null;
     }
 
-    @Override
-    public String getRealPath(final String path) {
-        return null;
-    }
-
     /**
      * @see ServletRequest#getRemoteAddr()
      */
@@ -551,16 +547,6 @@ public class JakartaMockServletHttpRequest implements HttpServletRequest {
     }
 
     /**
-     * @see HttpServletRequest#isRequestedSessionIdFromUrl()
-     * @deprecated
-     */
-    @Override
-    @Deprecated
-    public boolean isRequestedSessionIdFromUrl() {
-        return false;
-    }
-
-    /**
      * @see HttpServletRequest#isRequestedSessionIdFromURL()
      */
     @Override
@@ -654,8 +640,8 @@ public class JakartaMockServletHttpRequest implements HttpServletRequest {
         throw new IllegalStateException("Not implemented");
     }
 
-//    @Override
-//    public ServletConnection getServletConnection() {
-//        throw new IllegalStateException("Not implemented 6.0.0");
-//    }
+    @Override
+    public ServletConnection getServletConnection() {
+        throw new IllegalStateException("Not implemented");
+    }
 }


### PR DESCRIPTION
Done as a prerequisite of upgrading Apache Felix to Jakarta Servlet API 6.x. 

Please see https://issues.apache.org/jira/browse/FELIX-6612 and https://github.com/apache/felix-dev/pull/218 for more info.