### PR TITLE
OSGi metadata enhancements

### DIFF
--- a/commons-fileupload2-core/pom.xml
+++ b/commons-fileupload2-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/commons-fileupload2-distribution/pom.xml
+++ b/commons-fileupload2-distribution/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/commons-fileupload2-jakarta-servlet5/pom.xml
+++ b/commons-fileupload2-jakarta-servlet5/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -36,18 +36,24 @@
   <properties>
 	<commons.parent.dir>${basedir}/..</commons.parent.dir>
 	<commons.module.name>org.apache.commons.fileupload2.jakarta.servlet5</commons.module.name>
+
+	<!-- Override properties for the OSGi maven-bundle-plugin to generate proper manifest -->
+    <commons.osgi.requireCapability>osgi.contract;filter:="(&amp;(osgi.contract=JakartaServlet)(version=5.0))"</commons.osgi.requireCapability>
+
+	<!-- Override link to Jakarta EE -->
+	<commons.javadoc.javaee.link>https://jakarta.ee/specifications/platform/9.1/apidocs/</commons.javadoc.javaee.link>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/commons-fileupload2-jakarta-servlet6/pom.xml
+++ b/commons-fileupload2-jakarta-servlet6/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -35,19 +35,25 @@
 
   <properties>
 	<commons.parent.dir>${basedir}/..</commons.parent.dir>
-	<commons.module.name>org.apache.commons.fileupload2.jakarta.servlet6.servlet6.servlet6</commons.module.name>
+	<commons.module.name>org.apache.commons.fileupload2.jakarta.servlet6</commons.module.name>
+
+	<!-- Override properties for the OSGi maven-bundle-plugin to generate proper manifest -->
+    <commons.osgi.requireCapability>osgi.contract;filter:="(&amp;(osgi.contract=JakartaServlet)(version=6.0))"</commons.osgi.requireCapability>
+
+    <!-- Override link to Jakarta EE -->
+    <commons.javadoc.javaee.link>https://jakarta.ee/specifications/platform/10/apidocs/</commons.javadoc.javaee.link>	
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/commons-fileupload2-javax/pom.xml
+++ b/commons-fileupload2-javax/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -36,18 +36,22 @@
   <properties>
 	<commons.parent.dir>${basedir}/..</commons.parent.dir>
 	<commons.module.name>org.apache.commons.fileupload2.javax</commons.module.name>
+
+	<!-- Override properties for the OSGi maven-bundle-plugin to generate proper manifest -->
+    <commons.osgi.import>javax.servlet.*;version=${commons.servlet-api.version},*</commons.osgi.import>
+    <commons.osgi.requireCapability>osgi.contract;filter:="(&amp;(osgi.contract=JavaServlet)(version=${commons.servlet-api.version}))"</commons.osgi.requireCapability>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/commons-fileupload2-portlet/pom.xml
+++ b/commons-fileupload2-portlet/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-fileupload2</artifactId>
-    <version>2.0.0-M2-SNAPSHOT</version>
+    <version>2.0.0-M3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -36,30 +36,34 @@
   <properties>
 	<commons.parent.dir>${basedir}/..</commons.parent.dir>
 	<commons.module.name>org.apache.commons.fileupload2.portlet</commons.module.name>
+
+	<!-- Override properties for the OSGi maven-bundle-plugin to generate proper manifest -->
+    <commons.osgi.import>!javax.portlet,*</commons.osgi.import>
+    <commons.osgi.dynamicImport>javax.portlet</commons.osgi.dynamicImport>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-core</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-javax</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-fileupload2-javax</artifactId>
-      <version>2.0.0-M2-SNAPSHOT</version>
+      <version>2.0.0-M3-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>commons-fileupload2</artifactId>
-  <version>2.0.0-M2-SNAPSHOT</version>
+  <version>2.0.0-M3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Apache Commons FileUpload</name>
@@ -229,7 +229,7 @@
 	<commons.parent.dir>${basedir}</commons.parent.dir>
     <commons.componentid>fileupload</commons.componentid>
     <commons.module.name>org.apache.commons.fileupload2</commons.module.name>
-    <commons.release.version>2.0.0-M2</commons.release.version>
+    <commons.release.version>2.0.0-M3</commons.release.version>
     <commons.release.desc>in the org.apache.commons.fileupload2 namespace for Java 8 or later</commons.release.desc>
 
     <commons.release.2.version>1.5</commons.release.2.version>
@@ -244,9 +244,10 @@
     <commons.siteOutputDirectory>${basedir}/target/site</commons.siteOutputDirectory>
     <commons.releaseNotesLocation>${commons.parent.dir}/RELEASE-NOTES.txt</commons.releaseNotesLocation>
 
-    <commons.osgi.export>!org.apache.commons.fileupload.util.mime,org.apache.commons.*;version=${project.version};-noimport:=true</commons.osgi.export>
-    <commons.osgi.import>!javax.portlet,*</commons.osgi.import>
-    <commons.osgi.dynamicImport>javax.portlet</commons.osgi.dynamicImport>
+    <commons.osgi.export>!org.apache.commons.fileupload.util.mime,org.apache.commons.*;version=${project.version}</commons.osgi.export>
+    <!-- setting to true has a side effect of removing version information from 'Import-Package' manifest headers, which is incorrect -->
+    <commons.osgi.excludeDependencies>false</commons.osgi.excludeDependencies>
+
     <commons.servlet-api.version>2.5</commons.servlet-api.version>
     <commons.io.version>2.13.0</commons.io.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>
@@ -323,6 +324,16 @@
           <artifactId>spotbugs-maven-plugin</artifactId>
           <configuration>
             <excludeFilterFile>${commons.parent.dir}/spotbugs-exclude-filter.xml</excludeFilterFile>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <configuration>
+            <excludeDependencies>${commons.osgi.excludeDependencies}</excludeDependencies>
+            <instructions>
+              <Require-Capability>${commons.osgi.requireCapability}</Require-Capability>
+            </instructions>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
As a follow up to https://github.com/apache/commons-fileupload/pull/232, and subsequent https://github.com/apache/commons-fileupload/commit/33a8b5533d03c7a306e0ea82fca6881c8b551071 commit, which split Jakarta Servlet support into separate modules, here’s PR which focuses solely on OSGi metadata enhancements (and fixes), i.e.: 

 - Versioned imports
 - OSGi contract for JakartaServlet / JavaServlet
- 'javax.portlet' only in 'commons-fileupload2-portlet'