### PR TITLE
Fix off-by-one error when checking fileSizeMax

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputImpl.java
@@ -97,12 +97,15 @@ class FileItemInputImpl implements FileItemInput {
         final var itemInputStream = fileItemInputIteratorImpl.getMultiPartInput().newInputStream();
         InputStream istream = itemInputStream;
         if (fileSizeMax != -1) {
-            istream = new BoundedInputStream(istream, fileSizeMax) {
+            // onMaxLength will be called when the length is greater than _or equal to_ the supplied maxLength.
+            // Because we only want to throw an exception when the length is greater than fileSizeMax, we
+            // increment fileSizeMax by 1.
+            istream = new BoundedInputStream(istream, fileSizeMax + 1) {
                 @Override
                 protected void onMaxLength(final long sizeMax, final long count) throws IOException {
                     itemInputStream.close(true);
                     throw new FileUploadByteCountLimitException(
-                            String.format("The field %s exceeds its maximum permitted size of %s bytes.", fieldName, sizeMax), count, sizeMax, fileName,
+                            String.format("The field %s exceeds its maximum permitted size of %s bytes.", fieldName, fileSizeMax), count, fileSizeMax, fileName,
                             fieldName);
                 }
             };


### PR DESCRIPTION
The `onMaxLength` method of `BoundedInputStream` triggers when the `maxLength` is met or exceeded, and we want to throw an exception only when it is exceeded. To fix this, the `fileSizeMax` attribute is incremented before being passed to the bounded stream.

I've added tests to check the cases where the `fileSizeMax` equals the length of the stream, and where the length of the stream is one greater. Let me know if I need to file a JIRA issue to go along with this.