### PR TITLE
(doc) Fix instantiation of DiskFileItemFactory in migration guide

### DIFF
--- a/src/site/apt/migration.apt.vm
+++ b/src/site/apt/migration.apt.vm
@@ -160,7 +160,7 @@ Migrating
 	    @Override
 	    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		    if (JakartaServletFileUpload.isMultipartContent(req)) {
-			    final DiskFileItemFactory fileItemfactory = new DiskFileItemFactory();
+			    final DiskFileItemFactory fileItemfactory = DiskFileItemFactory.builder().get();
 			    final JakartaServletFileUpload fileUpload = new JakartaServletFileUpload(fileItemfactory);
 			    final List<FileItem> items;
 			    try {


### PR DESCRIPTION
DiskFileItemFactory has a private constructor.