### PR TITLE
[1.x] Enable multipart/related on FileUpload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,10 @@
       <name>fangwentong</name>
       <email>fangwentong2012@gmail.com</email>
     </contributor>
+    <contributor>
+      <name>mufasa1976</name>
+      <email>mufasa1976@coolstuff.software</email>
+    </contributor>
   </contributors>
 
   <scm>

--- a/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -1080,9 +1080,6 @@ public abstract class FileUploadBase {
                         eof = true;
                         return false;
                     }
-                    if (multipartRelated) {
-                      currentFieldName = null;
-                    }
 
                     // Inner multipart terminated -> Return to parsing the outer
                     multi.setBoundary(boundary);

--- a/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -140,7 +140,8 @@ public abstract class FileUploadBase {
 
     /**
      * HTTP content type header for multiple related data.
-     * @since 1.6
+     *
+     * @since 1.6.0
      */
     public static final String MULTIPART_RELATED = "multipart/related";
 

--- a/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -969,7 +969,7 @@ public abstract class FileUploadBase {
         /**
          * Is this a multipart/related Request.
          */
-        private boolean multipartRelated;
+        private final boolean multipartRelated;
 
         /**
          * Creates a new instance.

--- a/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -139,6 +139,11 @@ public abstract class FileUploadBase {
     public static final String MULTIPART_MIXED = "multipart/mixed";
 
     /**
+     * HTTP content type header for multiple related data.
+     */
+    public static final String MULTIPART_RELATED = "multipart/related";
+
+    /**
      * The maximum length of a single header line that will be parsed
      * (1024 bytes).
      * @deprecated This constant is no longer used. As of commons-fileupload
@@ -962,6 +967,11 @@ public abstract class FileUploadBase {
         private boolean eof;
 
         /**
+         * Is this a multipart/related Request.
+         */
+        private boolean multipartRelated;
+
+        /**
          * Creates a new instance.
          *
          * @param ctx The request context.
@@ -979,10 +989,11 @@ public abstract class FileUploadBase {
             if ((null == contentType)
                     || (!contentType.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART))) {
                 throw new InvalidContentTypeException(
-                        format("the request doesn't contain a %s or %s stream, content type header is %s",
-                               MULTIPART_FORM_DATA, MULTIPART_MIXED, contentType));
+                        format("the request neither contains a %s nor a %s nor a %s stream, content type header is %s",
+                               MULTIPART_FORM_DATA, MULTIPART_MIXED, MULTIPART_RELATED, contentType));
             }
 
+            multipartRelated = contentType.toLowerCase(Locale.ENGLISH).startsWith(MULTIPART_RELATED);
 
             @SuppressWarnings("deprecation") // still has to be backward compatible
             final int contentLengthInt = ctx.getContentLength();
@@ -1069,13 +1080,26 @@ public abstract class FileUploadBase {
                         eof = true;
                         return false;
                     }
+                    if (multipartRelated) {
+                      currentFieldName = null;
+                    }
+
                     // Inner multipart terminated -> Return to parsing the outer
                     multi.setBoundary(boundary);
                     currentFieldName = null;
                     continue;
                 }
                 final FileItemHeaders headers = getParsedHeaders(multi.readHeaders());
-                if (currentFieldName == null) {
+                if (multipartRelated) {
+                    currentFieldName = "";
+                    currentItem = new FileItemStreamImpl(
+                        null, null, headers.getHeader(CONTENT_TYPE),
+                        false, getContentLength(headers));
+                    currentItem.setHeaders(headers);
+                    notifier.noteItem();
+                    itemValid = true;
+                    return true;
+                } else if (currentFieldName == null) {
                     // We're parsing the outer multipart
                     final String fieldName = getFieldName(headers);
                     if (fieldName != null) {

--- a/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
+++ b/src/main/java/org/apache/commons/fileupload/FileUploadBase.java
@@ -140,6 +140,7 @@ public abstract class FileUploadBase {
 
     /**
      * HTTP content type header for multiple related data.
+     * @since 1.6
      */
     public static final String MULTIPART_RELATED = "multipart/related";
 
@@ -1080,7 +1081,6 @@ public abstract class FileUploadBase {
                         eof = true;
                         return false;
                     }
-
                     // Inner multipart terminated -> Return to parsing the outer
                     multi.setBoundary(boundary);
                     currentFieldName = null;

--- a/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.fileupload.portlet.PortletFileUploadTest;
@@ -395,5 +396,53 @@ public class FileUploadTest {
                 assertNull(value);
             }
         }
+    }
+
+    /**
+     * Test for multipart/related without any content-disposition Header.
+     * <p/>
+     * This kind of Content-Type is commonly used by SOAP-Requests with Attachments (MTOM)
+     */
+    @Test
+    public void testMultipartRelated() throws FileUploadException {
+        final String soapEnvelope =
+                "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\">\r\n" +
+                        "  <soap:Header></soap:Header>\r\n" +
+                        "  <soap:Body>\r\n" +
+                        "    <ns1:Test xmlns:ns1=\"http://www.test.org/some-test-namespace\">\r\n" +
+                        "      <ns1:Attachment>\r\n" +
+                        "        <xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\"" +
+                        " href=\"ref-to-attachment%40some.domain.org\"/>\r\n" +
+                        "      </ns1:Attachment>\r\n" +
+                        "    </ns1:Test>\r\n" +
+                        "  </soap:Body>\r\n" +
+                        "</soap:Envelope>";
+
+        final String content = "-----1234\r\n" +
+                "content-type: application/xop+xml; type=\"application/soap+xml\"\r\n" +
+                "\r\n" +
+                soapEnvelope + "\r\n" +
+                "-----1234\r\n" +
+                "Content-type: text/plain\r\n" +
+                "content-id: <ref-to-attachment@some.domain.org>\r\n" +
+                "\r\n" +
+                "some text/plain content\r\n" +
+                "-----1234--\r\n";
+
+        final List<FileItem> fileItems = Util.parseUpload(upload, content.getBytes(StandardCharsets.US_ASCII),
+                "multipart/related; boundary=---1234; type=\"application/xop+xml\"; start-info=\"application/soap+xml\"");
+        assertEquals(2, fileItems.size());
+
+        final FileItem part1 = fileItems.get(0);
+        assertNull(part1.getFieldName());
+        assertFalse(part1.isFormField());
+        assertEquals(soapEnvelope, part1.getString());
+
+        final FileItem part2 = fileItems.get(1);
+        assertNull(part2.getFieldName());
+        assertFalse(part2.isFormField());
+        assertEquals("some text/plain content", part2.getString());
+        assertEquals("text/plain", part2.getContentType());
+        assertNull(part2.getName());
     }
 }

--- a/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
@@ -407,16 +407,16 @@ public class FileUploadTest {
     public void testMultipartRelated() throws FileUploadException {
         final String soapEnvelope =
                 "<soap:Envelope xmlns:soap=\"http://www.w3.org/2003/05/soap-envelope\">\r\n" +
-                        "  <soap:Header></soap:Header>\r\n" +
-                        "  <soap:Body>\r\n" +
-                        "    <ns1:Test xmlns:ns1=\"http://www.test.org/some-test-namespace\">\r\n" +
-                        "      <ns1:Attachment>\r\n" +
-                        "        <xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\"" +
-                        " href=\"ref-to-attachment%40some.domain.org\"/>\r\n" +
-                        "      </ns1:Attachment>\r\n" +
-                        "    </ns1:Test>\r\n" +
-                        "  </soap:Body>\r\n" +
-                        "</soap:Envelope>";
+                "  <soap:Header></soap:Header>\r\n" +
+                "  <soap:Body>\r\n" +
+                "    <ns1:Test xmlns:ns1=\"http://www.test.org/some-test-namespace\">\r\n" +
+                "      <ns1:Attachment>\r\n" +
+                "        <xop:Include xmlns:xop=\"http://www.w3.org/2004/08/xop/include\"" +
+                " href=\"ref-to-attachment%40some.domain.org\"/>\r\n" +
+                "      </ns1:Attachment>\r\n" +
+                "    </ns1:Test>\r\n" +
+                "  </soap:Body>\r\n" +
+                "</soap:Envelope>";
 
         final String content = "-----1234\r\n" +
                 "content-type: application/xop+xml; type=\"application/soap+xml\"\r\n" +

--- a/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
@@ -400,7 +400,6 @@ public class FileUploadTest {
 
     /**
      * Test for multipart/related without any content-disposition Header.
-     * <p/>
      * This kind of Content-Type is commonly used by SOAP-Requests with Attachments (MTOM)
      */
     @Test

--- a/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
+++ b/src/test/java/org/apache/commons/fileupload/FileUploadTest.java
@@ -430,7 +430,8 @@ public class FileUploadTest {
                 "-----1234--\r\n";
 
         final List<FileItem> fileItems = Util.parseUpload(upload, content.getBytes(StandardCharsets.US_ASCII),
-                "multipart/related; boundary=---1234; type=\"application/xop+xml\"; start-info=\"application/soap+xml\"");
+                "multipart/related; boundary=---1234;" +
+                    " type=\"application/xop+xml\"; start-info=\"application/soap+xml\"");
         assertEquals(2, fileItems.size());
 
         final FileItem part1 = fileItems.get(0);


### PR DESCRIPTION
SOAP-Requests with MTOM enabled are sending the Requests with Content-Type `multipart/related`.

Because this Project is used by [Wiremock](https://github.com/wiremock/wiremock) it would fix the Issue [#2176: "multipart/related request matching fails if the content-disposition header is not present"](https://github.com/wiremock/wiremock/issues/2176)