### PR TITLE
Enable multipart/related on FileUpload

### DIFF
--- a/commons-fileupload2-core/pom.xml
+++ b/commons-fileupload2-core/pom.xml
@@ -42,7 +42,7 @@
     <commons.jacoco.instructionRatio>0.43</commons.jacoco.instructionRatio>
     <commons.jacoco.methodRatio>0.40</commons.jacoco.methodRatio>
     <commons.jacoco.branchRatio>0.43</commons.jacoco.branchRatio>
-    <commons.jacoco.lineRatio>0.41</commons.jacoco.lineRatio>
+    <commons.jacoco.lineRatio>0.42</commons.jacoco.lineRatio>
     <commons.jacoco.complexityRatio>0.37</commons.jacoco.complexityRatio>
   </properties>
   <dependencies>

--- a/commons-fileupload2-core/pom.xml
+++ b/commons-fileupload2-core/pom.xml
@@ -42,7 +42,7 @@
     <commons.jacoco.instructionRatio>0.43</commons.jacoco.instructionRatio>
     <commons.jacoco.methodRatio>0.40</commons.jacoco.methodRatio>
     <commons.jacoco.branchRatio>0.43</commons.jacoco.branchRatio>
-    <commons.jacoco.lineRatio>0.42</commons.jacoco.lineRatio>
+    <commons.jacoco.lineRatio>0.41</commons.jacoco.lineRatio>
     <commons.jacoco.complexityRatio>0.37</commons.jacoco.complexityRatio>
   </properties>
   <dependencies>

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
@@ -86,11 +86,13 @@ public abstract class AbstractRequestContext<T> implements RequestContext {
     }
 
     /**
-     * Test the given <code>content-type</code> Value if it is of type <code>multipart/related</code>.
-     * @param contentType <code>content-type</code> to be tested
-     * @return does the given <code>content-type</code> Value start with <code>multipart/related</code>
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
-    protected boolean isMultipartRelated(final String contentType) {
-        return MULTIPART_RELATED.matcher(contentType).matches();
+    @Override
+    public boolean isMultipartRelated() {
+        return MULTIPART_RELATED.matcher(getContentType()).matches();
     }
 }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractRequestContext<T> implements RequestContext {
     /**
-     * the Content-Type Pattern for multipart/related Requests.
+     * The Content-Type Pattern for multipart/related Requests.
      */
     private static final Pattern MULTIPART_RELATED =
             Pattern.compile("^\\s*multipart/related.*", Pattern.CASE_INSENSITIVE);
@@ -85,6 +85,11 @@ public abstract class AbstractRequestContext<T> implements RequestContext {
         return String.format("%s [ContentLength=%s, ContentType=%s]", getClass().getSimpleName(), getContentLength(), getContentType());
     }
 
+    /**
+     * Test the given <code>content-type</code> Value if it is of type <code>multipart/related</code>.
+     * @param contentType <code>content-type</code> to be tested
+     * @return does the given <code>content-type</code> Value start with <code>multipart/related</code>
+     */
     protected boolean isMultipartRelated(final String contentType) {
         return MULTIPART_RELATED.matcher(contentType).matches();
     }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
@@ -20,8 +20,14 @@ package org.apache.commons.fileupload2.core;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
+import java.util.regex.Pattern;
 
 public abstract class AbstractRequestContext<T> implements RequestContext {
+    /**
+     * the Content-Type Pattern for multipart/related Requests
+     */
+    private static final Pattern MULTIPART_RELATED =
+            Pattern.compile("^\\s*multipart/related.*", Pattern.CASE_INSENSITIVE);
 
     /**
      * Supplies the content length default.
@@ -79,4 +85,7 @@ public abstract class AbstractRequestContext<T> implements RequestContext {
         return String.format("%s [ContentLength=%s, ContentType=%s]", getClass().getSimpleName(), getContentLength(), getContentType());
     }
 
+    protected boolean isMultipartRelated(String contentType) {
+        return MULTIPART_RELATED.matcher(contentType).matches();
+    }
 }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractRequestContext.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractRequestContext<T> implements RequestContext {
     /**
-     * the Content-Type Pattern for multipart/related Requests
+     * the Content-Type Pattern for multipart/related Requests.
      */
     private static final Pattern MULTIPART_RELATED =
             Pattern.compile("^\\s*multipart/related.*", Pattern.CASE_INSENSITIVE);
@@ -85,7 +85,7 @@ public abstract class AbstractRequestContext<T> implements RequestContext {
         return String.format("%s [ContentLength=%s, ContentType=%s]", getClass().getSimpleName(), getContentLength(), getContentType());
     }
 
-    protected boolean isMultipartRelated(String contentType) {
+    protected boolean isMultipartRelated(final String contentType) {
         return MULTIPART_RELATED.matcher(contentType).matches();
     }
 }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
@@ -96,7 +96,7 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
     private boolean eof;
 
     /**
-     * is the Request of type <code>multipart/related</code>
+     * is the Request of type <code>multipart/related</code>.
      */
     private final boolean multipartRelated;
 

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
@@ -96,7 +96,7 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
     private boolean eof;
 
     /**
-     * is the Request of type <code>multipart/related</code>.
+     * Is the Request of type <code>multipart/related</code>.
      */
     private final boolean multipartRelated;
 

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
@@ -31,7 +31,6 @@ import org.apache.commons.io.input.BoundedInputStream;
  * The iterator returned by {@link AbstractFileUpload#getItemIterator(RequestContext)}.
  */
 class FileItemInputIteratorImpl implements FileItemInputIterator {
-
     /**
      * The file uploads processing utility.
      *
@@ -97,6 +96,11 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
     private boolean eof;
 
     /**
+     * is the Request of type <code>multipart/related</code>
+     */
+    private final boolean multipartRelated;
+
+    /**
      * Constructs a new instance.
      *
      * @param fileUploadBase Main processor.
@@ -109,6 +113,7 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
         this.sizeMax = fileUploadBase.getSizeMax();
         this.fileSizeMax = fileUploadBase.getFileSizeMax();
         this.requestContext = Objects.requireNonNull(requestContext, "requestContext");
+        this.multipartRelated = this.requestContext.isMultipartRelated();
         this.skipPreamble = true;
         findNextItem();
     }
@@ -147,7 +152,16 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
                 continue;
             }
             final var headers = fileUpload.getParsedHeaders(multi.readHeaders());
-            if (currentFieldName == null) {
+            if (multipartRelated) {
+                currentFieldName = "";
+                currentItem = new FileItemInputImpl(
+                        this, null, null, headers.getHeader(AbstractFileUpload.CONTENT_TYPE),
+                        false, getContentLength(headers));
+                currentItem.setHeaders(headers);
+                progressNotifier.noteItem();
+                itemValid = true;
+                return true;
+            } else  if (currentFieldName == null) {
                 // We're parsing the outer multipart
                 final var fieldName = fileUpload.getFieldName(headers);
                 if (fieldName != null) {

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RequestContext.java
@@ -70,4 +70,10 @@ public interface RequestContext {
      */
     InputStream getInputStream() throws IOException;
 
+    /**
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     */
+    boolean isMultipartRelated();
 }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RequestContext.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RequestContext.java
@@ -74,6 +74,7 @@ public interface RequestContext {
      * Is the Request of type <code>multipart/related</code>?
      *
      * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
     boolean isMultipartRelated();
 }

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/AbstractFileUploadTest.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/AbstractFileUploadTest.java
@@ -396,7 +396,6 @@ public abstract class AbstractFileUploadTest<AFU extends AbstractFileUpload<R, I
 
     /**
      * Test for multipart/related without any content-disposition Header.
-     * <p/>
      * This kind of Content-Type is commonly used by SOAP-Requests with Attachments (MTOM)
      */
     @Test

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MockRequestContextTest.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MockRequestContextTest.java
@@ -1,6 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.commons.fileupload2.core;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MockRequestContextTest.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MockRequestContextTest.java
@@ -1,0 +1,172 @@
+package org.apache.commons.fileupload2.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link AbstractRequestContext}
+ */
+public class MockRequestContextTest {
+    /**
+     * Test if the <code>content-length</code> Value is numeric.
+     */
+    @Test
+    public void getContentLengthByParsing() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "text/plain",
+                null);
+        assertEquals(1234L, request.getContentLength());
+    }
+
+    /**
+     * Test if the <code>content-length</code> Value is not numeric
+     * and the Default will be taken.
+     */
+    @Test
+    public void getContentLengthDefaultBecauseOfInvalidNumber() {
+        final RequestContext request = new MockRequestContext(
+                x -> "not-a-number",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "text/plain",
+                null);
+        assertEquals(5678L, request.getContentLength());
+    }
+
+    /**
+     * Test if the given <code>character-encoding</code> is a valid CharEncoding
+     */
+    @Test
+    public void getCharset() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "text/plain",
+                null);
+        assertEquals(StandardCharsets.US_ASCII, request.getCharset());
+    }
+
+    /**
+     * Test if the given <code>character-encoding</code> is an invalid CharEncoding
+     * and leads to {@link UnsupportedCharsetException}
+     */
+    @Test
+    public void getInvalidCharset() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "invalid-charset",
+                "text/plain",
+                null);
+        assertThrows(UnsupportedCharsetException.class, request::getCharset);
+    }
+
+    /**
+     * Test the <code>toString()</code> Output
+     */
+    @Test
+    public void testToString() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "text/plain",
+                null);
+        assertEquals("MockRequestContext [ContentLength=1234, ContentType=text/plain]", request.toString());
+    }
+
+    /**
+     * Test if the <code>content-type</code> is <code>multipart/related</code>
+     */
+    @Test
+    public void testIsMultipartRelated() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "multipart/related; boundary=---1234; type=\"application/xop+xml\"; start-info=\"application/soap+xml\"",
+                null);
+        assertTrue(request.isMultipartRelated());
+    }
+
+    /**
+     * Test if the <code>content-type</code> is not <code>multipart/related</code>
+     */
+    @Test
+    public void testIsNotMultipartRelated() {
+        final RequestContext request = new MockRequestContext(
+                x -> "1234",
+                () -> 5678L,
+                "Request",
+                "US-ASCII",
+                "text/plain",
+                null);
+        assertFalse(request.isMultipartRelated());
+    }
+
+    private static final class MockRequestContext extends AbstractRequestContext<Object> {
+        private final String characterEncoding;
+        private final String contentType;
+        private final InputStream inputStream;
+
+        private MockRequestContext(Function<String, String> contentLengthString,
+                                   LongSupplier contentLengthDefault,
+                                   Object request,
+                                   String characterEncoding,
+                                   String contentType,
+                                   InputStream inputStream) {
+            super(contentLengthString, contentLengthDefault, request);
+            this.characterEncoding = characterEncoding;
+            this.contentType = contentType;
+            this.inputStream = inputStream;
+        }
+
+        /**
+         * Gets the character encoding for the request.
+         *
+         * @return The character encoding for the request.
+         */
+        @Override
+        public String getCharacterEncoding() {
+            return characterEncoding;
+        }
+
+        /**
+         * Gets the content type of the request.
+         *
+         * @return The content type of the request.
+         */
+        @Override
+        public String getContentType() {
+            return contentType;
+        }
+
+        /**
+         * Gets the input stream for the request.
+         *
+         * @return The input stream for the request.
+         */
+        @Override
+        public InputStream getInputStream() {
+            return inputStream;
+        }
+    }
+}

--- a/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
@@ -72,6 +72,7 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
      * Is the Request of type <code>multipart/related</code>?
      *
      * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
     @Override
     public boolean isMultipartRelated() {

--- a/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
@@ -68,4 +68,13 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
         return getRequest().getInputStream();
     }
 
+    /**
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     */
+    @Override
+    public boolean isMultipartRelated() {
+        return isMultipartRelated(getRequest().getContentType());
+    }
 }

--- a/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet5/src/main/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletRequestContext.java
@@ -67,15 +67,4 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
     public InputStream getInputStream() throws IOException {
         return getRequest().getInputStream();
     }
-
-    /**
-     * Is the Request of type <code>multipart/related</code>?
-     *
-     * @return the Request is of type <code>multipart/related</code>
-     * @since 2.0.0
-     */
-    @Override
-    public boolean isMultipartRelated() {
-        return isMultipartRelated(getRequest().getContentType());
-    }
 }

--- a/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
@@ -72,6 +72,7 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
      * Is the Request of type <code>multipart/related</code>?
      *
      * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
     @Override
     public boolean isMultipartRelated() {

--- a/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
@@ -68,4 +68,13 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
         return getRequest().getInputStream();
     }
 
+    /**
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     */
+    @Override
+    public boolean isMultipartRelated() {
+        return isMultipartRelated(getRequest().getContentType());
+    }
 }

--- a/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
+++ b/commons-fileupload2-jakarta-servlet6/src/main/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletRequestContext.java
@@ -67,15 +67,4 @@ public class JakartaServletRequestContext extends AbstractRequestContext<HttpSer
     public InputStream getInputStream() throws IOException {
         return getRequest().getInputStream();
     }
-
-    /**
-     * Is the Request of type <code>multipart/related</code>?
-     *
-     * @return the Request is of type <code>multipart/related</code>
-     * @since 2.0.0
-     */
-    @Override
-    public boolean isMultipartRelated() {
-        return isMultipartRelated(getRequest().getContentType());
-    }
 }

--- a/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
+++ b/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
@@ -72,6 +72,7 @@ public class JavaxServletRequestContext extends AbstractRequestContext<HttpServl
      * Is the Request of type <code>multipart/related</code>?
      *
      * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
     @Override
     public boolean isMultipartRelated() {

--- a/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
+++ b/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
@@ -68,4 +68,13 @@ public class JavaxServletRequestContext extends AbstractRequestContext<HttpServl
         return getRequest().getInputStream();
     }
 
+    /**
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     */
+    @Override
+    public boolean isMultipartRelated() {
+        return isMultipartRelated(getRequest().getContentType());
+    }
 }

--- a/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
+++ b/commons-fileupload2-javax/src/main/java/org/apache/commons/fileupload2/javax/JavaxServletRequestContext.java
@@ -67,15 +67,4 @@ public class JavaxServletRequestContext extends AbstractRequestContext<HttpServl
     public InputStream getInputStream() throws IOException {
         return getRequest().getInputStream();
     }
-
-    /**
-     * Is the Request of type <code>multipart/related</code>?
-     *
-     * @return the Request is of type <code>multipart/related</code>
-     * @since 2.0.0
-     */
-    @Override
-    public boolean isMultipartRelated() {
-        return isMultipartRelated(getRequest().getContentType());
-    }
 }

--- a/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
+++ b/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
@@ -68,4 +68,13 @@ public class JavaxPortletRequestContext extends AbstractRequestContext<ActionReq
         return getRequest().getPortletInputStream();
     }
 
+    /**
+     * Is the Request of type <code>multipart/related</code>?
+     *
+     * @return the Request is of type <code>multipart/related</code>
+     */
+    @Override
+    public boolean isMultipartRelated() {
+        return isMultipartRelated(getRequest().getContentType());
+    }
 }

--- a/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
+++ b/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
@@ -72,6 +72,7 @@ public class JavaxPortletRequestContext extends AbstractRequestContext<ActionReq
      * Is the Request of type <code>multipart/related</code>?
      *
      * @return the Request is of type <code>multipart/related</code>
+     * @since 2.0.0
      */
     @Override
     public boolean isMultipartRelated() {

--- a/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
+++ b/commons-fileupload2-portlet/src/main/java/org/apache/commons/fileupload2/portlet/JavaxPortletRequestContext.java
@@ -67,15 +67,4 @@ public class JavaxPortletRequestContext extends AbstractRequestContext<ActionReq
     public InputStream getInputStream() throws IOException {
         return getRequest().getPortletInputStream();
     }
-
-    /**
-     * Is the Request of type <code>multipart/related</code>?
-     *
-     * @return the Request is of type <code>multipart/related</code>
-     * @since 2.0.0
-     */
-    @Override
-    public boolean isMultipartRelated() {
-        return isMultipartRelated(getRequest().getContentType());
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,10 @@
       <name>Martin Grigorov</name>
       <email>mgrigorov@apache.org</email>
     </contributor>
+    <contributor>
+      <name>mufasa1976</name>
+      <email>mufasa1976@coolstuff.software</email>
+    </contributor>
   </contributors>
 
   <scm>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -48,6 +48,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action                        dev="ggregory" type="fix" due-to="Gregor Dschung">[site] Fix instantiation of DiskFileItemFactory in migration guide #273.</action>
       <action issue="FILEUPLOAD-355" dev="ggregory" type="fix" due-to="Ana, Gary Gregory">[site] Update code example: Use IOUtils instead of Streams utils class.</action>
       <!-- ADD -->
+      <action                        dev="mufasa1976" type="add">handle multipart/related Requests without content-disposition header</action>
       <!-- UDPATE -->
       <action                        dev="ggregory" type="update" due-to="Gary Gregory">Bump org.apache.commons:commons-parent from 66 to 69 #283, #294.</action>
       <action                        dev="ggregory" type="update" due-to="Gary Gregory">Bump commons-io:commons-io from 2.16.0 to 2.16.1 #297.</action>


### PR DESCRIPTION
SOAP-Requests with MTOM enabled are sending the Requests with Content-Type `multipart/related`.
Because the Parts would not have `content-disposition` Headers they would not be recognized by the FileUploads as Parts.

Because this Project is used by [Wiremock](https://github.com/wiremock/wiremock) it would fix the Issue https://github.com/wiremock/wiremock/issues/2176