### PR TITLE
FILEUPLOAD-356: Fix incorrect link to changes report in Commons FileUpload

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -73,7 +73,7 @@
         </li>
       </ul>
       <ul>
-        <li>Read the <a href=".changes-report.html">changes report</a>.
+        <li>Read the <a href="changes-report.html">changes report</a>.
         </li>
       </ul>
     </section>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FILEUPLOAD-356

This pull request corrects the URL for the “changes report” link on the Apache Commons FileUpload page. The previous link pointed to an incorrect path, which has now been updated to ensure users are directed to the correct changes report. This small fix improves user navigation and ensures accurate information is readily accessible.