### PR TITLE
AbstractFileUpload support for partHeaderSizeMax limit

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractFileUpload.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/AbstractFileUpload.java
@@ -135,6 +135,11 @@ public abstract class AbstractFileUpload<R, I extends FileItem<I>, F extends Fil
     private long fileCountMax = -1;
 
     /**
+     * The maximum permitted size of the headers provided with a single part in bytes.
+     */
+    private int partHeaderSizeMax = MultipartInput.DEFAULT_PART_HEADER_SIZE_MAX;
+
+    /**
      * The content encoding to use when reading part headers.
      */
     private Charset headerCharset;
@@ -348,6 +353,17 @@ public abstract class AbstractFileUpload<R, I extends FileItem<I>, F extends Fil
     }
 
     /**
+     * Gets the per part size limit for headers.
+     *
+     * @return The maximum size of the headers for a single part in bytes.
+     *
+     * @since 2.0.0-M5
+     */
+    public int getPartHeaderSizeMax() {
+        return partHeaderSizeMax;
+    }
+
+    /**
      * Gets the progress listener.
      *
      * @return The progress listener, if any, or null.
@@ -546,6 +562,17 @@ public abstract class AbstractFileUpload<R, I extends FileItem<I>, F extends Fil
      */
     public void setHeaderCharset(final Charset headerCharset) {
         this.headerCharset = headerCharset;
+    }
+
+    /**
+     * Sets the per part size limit for headers.
+     *
+     * @param partHeaderSizeMax The maximum size of the headers in bytes.
+     *
+     * @since 2.0.0-M5
+     */
+    public void setPartHeaderSizeMax(final int partHeaderSizeMax) {
+        this.partHeaderSizeMax = partHeaderSizeMax;
     }
 
     /**

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
@@ -286,7 +286,12 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
 
         progressNotifier = new MultipartInput.ProgressNotifier(fileUploadBase.getProgressListener(), requestSize);
         try {
-            multiPartInput = MultipartInput.builder().setInputStream(inputStream).setBoundary(multiPartBoundary).setProgressNotifier(progressNotifier).get();
+            multiPartInput = MultipartInput.builder()
+                .setInputStream(inputStream)
+                .setBoundary(multiPartBoundary)
+                .setProgressNotifier(progressNotifier)
+                .setPartHeaderSizeMax(fileUploadBase.getPartHeaderSizeMax())
+                .get();
         } catch (final IllegalArgumentException e) {
             IOUtils.closeQuietly(inputStream); // avoid possible resource leak
             throw new FileUploadContentTypeException(String.format("The boundary specified in the %s header is too long", AbstractFileUpload.CONTENT_TYPE), e);

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MultipartInput.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MultipartInput.java
@@ -160,15 +160,15 @@ public final class MultipartInput {
             return this;
         }
 
-       /** Sets the per part size limit for headers.
-     * @param partHeaderSizeMax The maximum size of the headers in bytes.
-     * @return This builder.
-     * @since 2.0.0-M4
-     */
-    public Builder setPartHeaderSizeMax(final int partHeaderSizeMax) {
-        this.partHeaderSizeMax = partHeaderSizeMax;
-        return this;
-    }
+        /** Sets the per part size limit for headers.
+         * @param partHeaderSizeMax The maximum size of the headers in bytes.
+         * @return This builder.
+         * @since 2.0.0-M4
+         */
+        public Builder setPartHeaderSizeMax(final int partHeaderSizeMax) {
+            this.partHeaderSizeMax = partHeaderSizeMax;
+            return this;
+        }
 
         /**
              * Sets the progress notifier.

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/AbstractSizesTest.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/AbstractSizesTest.java
@@ -40,6 +40,36 @@ public abstract class AbstractSizesTest<AFU extends AbstractFileUpload<R, I, F>,
         extends AbstractTest<AFU, R, I, F> {
 
     /**
+     * Checks whether limiting the PartHeaderSizeMax works.
+     *
+     * @throws IOException Test failure.
+     */
+    @Test
+    void testFilePartHeaderSizeMax() throws IOException {
+        final String request = "-----1234\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"foo.tab\"\r\n" +
+            "Content-Type: text/whatever\r\n" +
+            "Content-Length: 10\r\n" +
+            "\r\n" +
+            "This is the content of the file\n" +
+            "\r\n" +
+            "-----1234--\r\n";
+
+        final var upload = newFileUpload();
+        upload.setPartHeaderSizeMax(200);
+        final var req = newMockHttpServletRequest(request, null, null);
+        final var fileItems = upload.parseRequest(req);
+        assertEquals(1, fileItems.size());
+        final var item = fileItems.get(0);
+        assertEquals("This is the content of the file\n", new String(item.get()));
+
+        var upload2 = newFileUpload();
+        upload2.setPartHeaderSizeMax(10);
+        var req2 = newMockHttpServletRequest(request, null, null);
+        assertThrows(FileUploadSizeException.class, () -> upload2.parseRequest(req2));
+    }
+
+    /**
      * Checks, whether limiting the file size works.
      *
      * @throws IOException Test failure.


### PR DESCRIPTION
Problem: [commit](https://github.com/apache/commons-fileupload/commit/e5b5543b3a40ac9dde3c33ef1858901b3ca6656a) added partHeaderSizeMax to MultipartInput but unable to configure via AbstractFileUpload.

This adds the ability to configure partHeaderSizeMax via AbstractFileUpload for CVE-2025-48976.