### PR TITLE
RFC2231Utils decodeText - Incorrect handling of percent encoded text

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
@@ -137,8 +137,13 @@ final class RFC2231Utils {
                 if (i > text.length() - 2) {
                     break; // unterminated sequence
                 }
-                final var b1 = HEX_DECODE[text.charAt(i++) & MASK];
-                final var b2 = HEX_DECODE[text.charAt(i++) & MASK];
+                final var c1 = text.charAt(i++);
+                final var c2 = text.charAt(i++);
+                if (c1 >= ASCII_CODE_POINT_COUNT || c2 >= ASCII_CODE_POINT_COUNT) {
+                    // throw new IllegalArgumentException();
+                }
+                final var b1 = HEX_DECODE[c1 & MASK];
+                final var b2 = HEX_DECODE[c2 & MASK];
                 if (b1 < 0 || b2 < 0) {
                     throw new IllegalArgumentException();
                 }

--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
@@ -140,7 +140,7 @@ final class RFC2231Utils {
                 final var c1 = text.charAt(i++);
                 final var c2 = text.charAt(i++);
                 if (c1 >= ASCII_CODE_POINT_COUNT || c2 >= ASCII_CODE_POINT_COUNT) {
-                    // throw new IllegalArgumentException();
+                     throw new IllegalArgumentException();
                 }
                 final var b1 = HEX_DECODE[c1 & MASK];
                 final var b2 = HEX_DECODE[c2 & MASK];

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/RFC2231UtilityTestCase.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/RFC2231UtilityTestCase.java
@@ -100,4 +100,9 @@ public final class RFC2231UtilityTestCase {
     void testDecodeInvalidHex() throws Exception {
         assertThrows(IllegalArgumentException.class, () -> RFC2231Utils.decodeText("ISO-8859-1''hello%HHworld"));
     }
+    
+    @Test
+    void testDecodeInvalidPercentEncoded() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> RFC2231Utils.decodeText("ISO-8859-1''hello%3\u8a35"));
+    }
 }


### PR DESCRIPTION
Issue: decoded text does not conform rfc2231 was incorrectly decoded, e.g., `utf-8''%3\u8a35` -> `5`

Expectation: illegal format.

Code change: check the next 2 chars after percent %, ensure %HH format per RFC 2231, raise iae if not.

Testcase attached.