### PR TITLE
Reject truncated percent-encoding in RFC2231Utils.decodeText

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/RFC2231Utils.java
@@ -130,7 +130,8 @@ final class RFC2231Utils {
             final var c = text.charAt(i++);
             if (c == '%') {
                 if (i > text.length() - 2) {
-                    break; // unterminated sequence
+                    // A '%' that is not followed by two hex digits is a truncated escape sequence.
+                    throw new IllegalArgumentException();
                 }
                 final var c1 = text.charAt(i++);
                 final var c2 = text.charAt(i++);

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/RFC2231UtilityTestCase.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/RFC2231UtilityTestCase.java
@@ -52,6 +52,12 @@ public final class RFC2231UtilityTestCase {
     }
 
     @Test
+    void testDecodeTruncatedPercentEncoded() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> RFC2231Utils.decodeText("ISO-8859-1''hello%"));
+        assertThrows(IllegalArgumentException.class, () -> RFC2231Utils.decodeText("ISO-8859-1''hello%3"));
+    }
+
+    @Test
     void testDecodeIso88591() throws Exception {
         assertEncoded("\u00A3 rate", "iso-8859-1'en'%A3%20rate"); // "£ rate"
     }


### PR DESCRIPTION
Repro: parse a `Content-Disposition` value of `form-data; name="f"; filename*=UTF-8''report%3` (a truncated RFC 5987 percent escape) and read the resulting file name.
Expected: rejected, the same as `%GG` or a non-ASCII byte already are.
Actual: `RFC2231Utils.decodeText` returns `report`; `fromHex` treats a `%` with fewer than two following characters as end-of-input and returns what it decoded so far, dropping the truncated escape.
Fix: throw `IllegalArgumentException` on a truncated `%` escape, so the value is rejected like every other malformed input in `fromHex` and like the sibling `QuotedPrintableDecoder`. Covered by a new case in `RFC2231UtilityTestCase`.