### PR TITLE
Match RFC 2047 encoding token case-insensitively in decodeWord

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MimeUtils.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MimeUtils.java
@@ -224,10 +224,10 @@ final class MimeUtils {
 
             final var encodedData = encodedText.getBytes(StandardCharsets.US_ASCII);
 
-            // Base64 encoded?
-            if (encoding.equals(BASE64_ENCODING_MARKER)) {
+            // Base64 encoded? RFC 2047 section 2 defines the encoding token as case-independent, so 'b' and 'q' are also valid.
+            if (encoding.equalsIgnoreCase(BASE64_ENCODING_MARKER)) {
                 out.write(Base64.getMimeDecoder().decode(encodedData));
-            } else if (encoding.equals(QUOTEDPRINTABLE_ENCODING_MARKER)) { // maybe quoted printable.
+            } else if (encoding.equalsIgnoreCase(QUOTEDPRINTABLE_ENCODING_MARKER)) { // maybe quoted printable.
                 QuotedPrintableDecoder.decode(encodedData, out);
             } else {
                 throw new UnsupportedEncodingException("Unknown RFC 2047 encoding: " + encoding);

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MimeUtilityTestCase.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MimeUtilityTestCase.java
@@ -55,8 +55,20 @@ public final class MimeUtilityTestCase {
     }
 
     @Test
+    void testDecodeUtf8Base64EncodedLowerCaseMarker() throws Exception {
+        // RFC 2047 section 2: the encoding token is case-independent, so 'b' decodes like 'B'.
+        assertEncoded(" h\u00e9! \u00e0\u00e8\u00f4u !!!", "=?UTF-8?b?IGjDqSEgw6DDqMO0dSAhISE=?=");
+    }
+
+    @Test
     void testDecodeUtf8QuotedPrintableEncoded() throws Exception {
         assertEncoded(" h\u00e9! \u00e0\u00e8\u00f4u !!!", "=?UTF-8?Q?_h=C3=A9!_=C3=A0=C3=A8=C3=B4u_!!!?=");
+    }
+
+    @Test
+    void testDecodeUtf8QuotedPrintableEncodedLowerCaseMarker() throws Exception {
+        // RFC 2047 section 2: the encoding token is case-independent, so 'q' decodes like 'Q'.
+        assertEncoded(" h\u00e9! \u00e0\u00e8\u00f4u !!!", "=?UTF-8?q?_h=C3=A9!_=C3=A0=C3=A8=C3=B4u_!!!?=");
     }
 
     @Test


### PR DESCRIPTION
`Repro:` `Content-Disposition: attachment; filename="=?utf-8?b?ZXZpbC5leGU=?="`, a valid RFC 2047 encoded-word that uses the lower-case `b` marker.
`Expected:` the filename decodes to `evil.exe`, matching the upper-case `=?utf-8?B?...?=` form.
`Actual:` `MimeUtils.decodeWord` throws `UnsupportedEncodingException`, so `ParameterParser` keeps the raw value `=?utf-8?b?ZXZpbC5leGU=?=`. Lower-case `q` behaves the same way against the `Q` marker.
`Cause:` the charset token is lower-cased before use, but the encoding token is compared case-sensitively with `encoding.equals("B")` / `equals("Q")`. RFC 2047 section 2 defines the encoding as case-independent (`b` == `B`, `q` == `Q`).
`Fix:` compare the encoding token with `equalsIgnoreCase`, so `b`/`q` decode identically to `B`/`Q`. Two regression tests cover the lower-case base64 and quoted-printable markers; both fail before the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
