### PR TITLE
Reject truncated percent-encoding in RFC2231Utility.decodeText

### DIFF
--- a/src/main/java/org/apache/commons/fileupload/RFC2231Utility.java
+++ b/src/main/java/org/apache/commons/fileupload/RFC2231Utility.java
@@ -139,7 +139,8 @@ final class RFC2231Utility {
             final char c = text.charAt(i++);
             if (c == PERCENT) {
                 if (i > text.length() - 2) {
-                    break; // unterminated sequence
+                    // A '%' that is not followed by two hex digits is a truncated escape sequence.
+                    throw new IllegalArgumentException();
                 }
                 final char c1 = text.charAt(i++);
                 final char c2 = text.charAt(i++);

--- a/src/test/java/org/apache/commons/fileupload/RFC2231UtilityTestCase.java
+++ b/src/test/java/org/apache/commons/fileupload/RFC2231UtilityTestCase.java
@@ -76,6 +76,13 @@ public final class RFC2231UtilityTestCase {
 
 
     @Test
+    void testDecodeTruncatedPercentEncoded() throws Exception {
+        assertThrows(IllegalArgumentException.class, () -> RFC2231Utility.decodeText("ISO-8859-1''hello%"));
+        assertThrows(IllegalArgumentException.class, () -> RFC2231Utility.decodeText("ISO-8859-1''hello%3"));
+    }
+
+
+    @Test
     void testDecodeUTF8Characters() throws Exception {
         assertThrows(IllegalArgumentException.class, () -> RFC2231Utility.decodeText("UTF-8''\\u8a2e"));
     }


### PR DESCRIPTION
Port of #475 to `1.x`, as requested there. Same change as merged on `master`, adapted to `RFC2231Utility`.

Repro: `RFC2231Utility.decodeText("UTF-8''report%3")` (a truncated RFC 5987 percent escape, reachable via `filename*`).
Expected: rejected, the same as `%GG` or a non-ASCII byte already are.
Actual: returns `report`; `fromHex` treats a `%` with fewer than two following characters as end-of-input and drops the truncated escape.
Fix: throw `IllegalArgumentException`, matching the other malformed-input paths in `fromHex`. Covered by a new case in `RFC2231UtilityTestCase`; full suite passes on `1.x` (86 tests, 0 failures).