### PR TITLE
Reject malformed base64 payload in RFC 2047 decodeWord

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MimeUtils.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/MimeUtils.java
@@ -235,7 +235,9 @@ final class MimeUtils {
             // get the decoded byte data and convert into a string.
             final var decodedData = out.toByteArray();
             return new String(decodedData, javaCharset(charset));
-        } catch (final IOException e) {
+        } catch (final IOException | IllegalArgumentException e) {
+            // IllegalArgumentException is thrown by the Base64 decoder on a malformed final unit; treat it like a
+            // quoted-printable decode failure so both encodings reject malformed input the same way.
             throw new UnsupportedEncodingException("Invalid RFC 2047 encoding");
         }
     }

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MimeUtilityTestCase.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/MimeUtilityTestCase.java
@@ -33,6 +33,13 @@ public final class MimeUtilityTestCase {
     }
 
     @Test
+    void testDecodeInvalidBase64() {
+        // A base64 payload whose final unit is truncated ("A" is a single base64 char) is rejected the same way as a
+        // malformed quoted-printable payload, rather than leaking an IllegalArgumentException from the base64 decoder.
+        assertThrows(UnsupportedEncodingException.class, () -> MimeUtils.decodeText("=?UTF-8?B?A?="));
+    }
+
+    @Test
     void testDecodeInvalidEncoding() {
         assertThrows(UnsupportedEncodingException.class, () -> MimeUtils.decodeText("=?invalid?B?xyz-?="));
     }


### PR DESCRIPTION
`MimeUtils.decodeWord` decodes an RFC 2047 encoded-word reached from a `Content-Disposition` / `Content-Type` parameter (`filename`, `name`, `boundary`) via `ParameterParser`. The base64 branch calls `Base64.getMimeDecoder().decode(...)`, which throws `IllegalArgumentException` on a malformed final unit. That is not caught by the surrounding `catch (IOException)`, so it escapes the method's declared `throws ParseException, UnsupportedEncodingException`. The quoted-printable branch throws `IOException` on the same kind of malformed input and is remapped cleanly, so the two encodings reject bad input inconsistently.

Repro: `MimeUtils.decodeText("=?UTF-8?B?A?=")` (payload is a single base64 char).
Expected: `UnsupportedEncodingException`, as for a malformed `Q` payload.
Actual: `IllegalArgumentException` ("Last unit does not have enough valid bits").

Widen the existing catch to `IOException | IllegalArgumentException` so a malformed base64 payload is rejected like a malformed quoted-printable one. Keeping the mapping in `decodeWord` keeps both encodings within the same declared contract instead of leaking a base64-specific runtime exception. Covered by a new case in `MimeUtilityTestCase`.