### PR TITLE
Ignore invalid RFC 2231 extended value so it cannot erase a valid filename

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/ParameterParser.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/ParameterParser.java
@@ -169,6 +169,7 @@ public class ParameterParser {
         while (hasChar()) {
             paramName = parseToken(new char[] { '=', separator });
             paramValue = null;
+            var invalid = false;
             if (hasChar() && charArray[pos] == '=') {
                 pos++; // skip '='
                 paramValue = parseQuotedToken(new char[] { separator });
@@ -177,8 +178,8 @@ public class ParameterParser {
                     try {
                         paramValue = RFC2231Utils.hasEncodedValue(paramName) ? RFC2231Utils.decodeText(paramValue) : MimeUtils.decodeText(paramValue);
                     } catch (final IllegalArgumentException iae) {
-                        // Treat invalid values as if they were not provided
-                        paramValue = null;
+                        // Treat invalid values as if they were not provided, so a malformed filename* cannot override a valid filename.
+                        invalid = true;
                     } catch (final UnsupportedEncodingException ignored) {
                         // let's keep the original value in this case
                     }
@@ -187,7 +188,7 @@ public class ParameterParser {
             if (hasChar() && charArray[pos] == separator) {
                 pos++; // skip separator
             }
-            if (paramName != null && !paramName.isEmpty()) {
+            if (!invalid && paramName != null && !paramName.isEmpty()) {
                 paramName = RFC2231Utils.stripDelimiter(paramName);
                 if (this.lowerCaseNames) {
                     paramName = paramName.toLowerCase(Locale.ROOT);

--- a/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/ParameterParserTest.java
+++ b/commons-fileupload2-core/src/test/java/org/apache/commons/fileupload2/core/ParameterParserTest.java
@@ -99,6 +99,34 @@ class ParameterParserTest {
         assertEquals("a'b'c", params.get("filename"));
     }
 
+    /**
+     * An invalid RFC 2231 / RFC 5987 extended value must be ignored rather than overwrite a valid plain value for the same parameter.
+     */
+    @Test
+    void testInvalidExtendedValueIgnored() {
+        final var parser = new ParameterParser();
+
+        // A truncated %nn escape in filename* must not erase the valid filename.
+        var s = "Content-Disposition: form-data; name=\"file\"; filename=\"safe.txt\"; filename*=UTF-8''bad%2\r\n";
+        var params = parser.parse(s, new char[] { ',', ';' });
+        assertEquals("safe.txt", params.get("filename"));
+
+        // Order independent: an invalid filename* before the valid filename is also ignored.
+        s = "Content-Disposition: form-data; name=\"file\"; filename*=UTF-8''bad%2; filename=\"safe.txt\"\r\n";
+        params = parser.parse(s, new char[] { ',', ';' });
+        assertEquals("safe.txt", params.get("filename"));
+
+        // An invalid filename* on its own is not reported as a (null) value.
+        s = "Content-Disposition: form-data; name=\"file\"; filename*=UTF-8''bad%2\r\n";
+        params = parser.parse(s, new char[] { ',', ';' });
+        assertNull(params.get("filename"));
+
+        // A valid filename* still decodes normally.
+        s = "Content-Disposition: form-data; name=\"file\"; filename=\"safe.txt\"; filename*=UTF-8''real.exe\r\n";
+        params = parser.parse(s, new char[] { ',', ';' });
+        assertEquals("real.exe", params.get("filename"));
+    }
+
     @Test
     void testParsing() {
         var s = "test; test1 =  stuff   ; test2 =  \"stuff; stuff\"; test3=\"stuff";


### PR DESCRIPTION
When `ParameterParser.parse` decodes an RFC 2231 / RFC 5987 extended value (such as `filename*`) and the decode throws `IllegalArgumentException`, it set the value to `null` and then unconditionally stored it. Because `filename` and `filename*` both strip to the key `filename`, a malformed `filename*` clobbers a valid `filename` for the same part. Repro: `parse("form-data; name=\"file\"; filename=\"safe.txt\"; filename*=UTF-8'bad%2", new char[]{',',';'})`. Expected: `filename` stays `safe.txt`. Actual: `filename` is `null`, so `getFileName` returns an empty name. A client controlling the multipart `Content-Disposition` header can therefore blank the filename of an uploaded file and slip past filename-based checks in callers.

The existing comment already states the intent (`Treat invalid values as if they were not provided`), but setting `paramValue = null` and putting it does the opposite for a parameter that also has a valid sibling value. The fix flags the invalid decode and skips storing that parameter, so an invalid extended value is genuinely ignored and cannot overwrite a valid one, regardless of ordering. Keeping this in `parse` means every caller (`getFileName`, `getFieldName`, `getBoundary`, charset lookup) gets the corrected behaviour without its own guard. Covered by a new `ParameterParserTest` case; the core suite passes (72 tests).
