### PR TITLE
FileItemInputIteratorImpl.findNextItem() now uses the max file count.

### DIFF
--- a/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
+++ b/commons-fileupload2-core/src/main/java/org/apache/commons/fileupload2/core/FileItemInputIteratorImpl.java
@@ -58,6 +58,16 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
     private long maxFileSize;
 
     /**
+     * The current number of files.
+     */
+    private long curFileCount;
+
+    /**
+     * The maximum permitted number of files that may be uploaded in a single request. A value of -1 indicates no maximum.
+     */
+    private final long maxFileCount;
+
+    /**
      * The multi part stream to process.
      */
     private MultipartInput multiPartInput;
@@ -114,10 +124,17 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
         this.fileUpload = fileUpload;
         this.maxSize = fileUpload.getMaxSize();
         this.maxFileSize = fileUpload.getMaxFileSize();
+        this.maxFileCount = fileUpload.getMaxFileCount();
         this.requestContext = Objects.requireNonNull(requestContext, "requestContext");
         this.multipartRelated = this.requestContext.isMultipartRelated();
         this.skipPreamble = true;
         findNextItem();
+    }
+
+    private void checkMaxFileCount() throws FileUploadFileCountLimitException {
+        if (curFileCount == maxFileCount) {
+            throw new FileUploadFileCountLimitException(String.format("Maximum file count %,d exceeded.", maxFileCount), maxFileCount, curFileCount);
+        }
     }
 
     /**
@@ -155,13 +172,10 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
             }
             final var headers = fileUpload.getParsedHeaders(multi.readHeaders());
             if (multipartRelated) {
+                checkMaxFileCount();
                 currentFieldName = "";
-                currentItem = new FileItemInputImpl(
-                        this, null, null, headers.getHeader(AbstractFileUpload.CONTENT_TYPE),
-                        false, getContentLength(headers));
-                currentItem.setHeaders(headers);
-                progressNotifier.noteItem();
-                itemValid = true;
+                currentItem = new FileItemInputImpl(this, null, null, headers.getHeader(AbstractFileUpload.CONTENT_TYPE), false, getContentLength(headers));
+                itemValid(headers);
                 return true;
             }
             if (currentFieldName == null) {
@@ -180,22 +194,20 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
                         skipPreamble = true;
                         continue;
                     }
+                    checkMaxFileCount();
                     final var fileName = fileUpload.getFileName(headers);
                     currentItem = new FileItemInputImpl(this, fileName, fieldName, headers.getHeader(AbstractFileUpload.CONTENT_TYPE), fileName == null,
                             getContentLength(headers));
-                    currentItem.setHeaders(headers);
-                    progressNotifier.noteItem();
-                    itemValid = true;
+                    itemValid(headers);
                     return true;
                 }
             } else {
                 final var fileName = fileUpload.getFileName(headers);
                 if (fileName != null) {
+                    checkMaxFileCount();
                     currentItem = new FileItemInputImpl(this, fileName, currentFieldName, headers.getHeader(AbstractFileUpload.CONTENT_TYPE), false,
                             getContentLength(headers));
-                    currentItem.setHeaders(headers);
-                    progressNotifier.noteItem();
-                    itemValid = true;
+                    itemValid(headers);
                     return true;
                 }
             }
@@ -304,6 +316,13 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
         multiPartInput.setHeaderCharset(charset);
     }
 
+    private void itemValid(final FileItemHeaders headers) {
+        currentItem.setHeaders(headers);
+        progressNotifier.noteItem();
+        itemValid = true;
+        curFileCount++;
+    }
+
     /**
      * Returns the next available {@link FileItemInput}.
      *
@@ -336,5 +355,4 @@ class FileItemInputIteratorImpl implements FileItemInputIterator {
         // TODO Something better?
         return (Iterator<FileItemInput>) this;
     }
-
 }

--- a/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
@@ -56,6 +56,33 @@ class JakartaServletFileUploadGetItemIteratorTest {
     /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
 
+    /** Boundary value used for nested multipart/mixed parts. */
+    private static final String MIXED_BOUNDARY = "---9876";
+
+    /**
+     * Builds a complete multipart body that contains a single form-data part holding a nested multipart/mixed part with {@code fileCount} identical files.
+     *
+     * @param fileCount number of nested files to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMixedFileParts(final int fileCount) {
+        final var sb = new StringBuilder();
+        sb.append("--").append(BOUNDARY).append("\r\n");
+        sb.append("Content-Disposition: form-data; name=\"files\"\r\n");
+        sb.append("Content-Type: multipart/mixed; boundary=").append(MIXED_BOUNDARY).append("\r\n");
+        sb.append("\r\n");
+        for (int i = 1; i <= fileCount; i++) {
+            sb.append("--").append(MIXED_BOUNDARY).append("\r\n");
+            sb.append("Content-Disposition: attachment; filename=\"file").append(i).append(".txt\"\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("\r\n");
+            sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(MIXED_BOUNDARY).append("--\r\n");
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
      *
@@ -373,6 +400,28 @@ class JakartaServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of files in a nested multipart/mixed part exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartMixedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMixedFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
@@ -34,6 +34,8 @@ import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -129,11 +131,11 @@ class JakartaServletFileUploadGetItemIteratorTest {
 
     /**
      * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
-     * permitted count.
+     * permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
      */
-    @Test
-    void testFileCountLimitExceededThrowsException() throws Exception {
-        final long maxFileCount = 2;
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
         final var body = buildMultiFileParts((int) maxFileCount + 1);
         final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
         final var upload = newUpload();
@@ -147,21 +149,6 @@ class JakartaServletFileUploadGetItemIteratorTest {
         // The next hasNext() call triggers the limit check
         final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
         assertEquals(maxFileCount, ex.getPermitted());
-    }
-
-    /**
-     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
-     */
-    @Test
-    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
-        final var body = buildMultiFileParts(2);
-        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
-        final var upload = newUpload();
-        upload.setMaxFileCount(1L);
-        final FileItemInputIterator iter = upload.getItemIterator(request);
-        assertTrue(iter.hasNext());
-        iter.next(); // consume the first (allowed) item
-        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
@@ -53,6 +53,9 @@ class JakartaServletFileUploadGetItemIteratorTest {
     /** Content-type header value that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE = "multipart/form-data; boundary=" + BOUNDARY;
 
+    /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
+    private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
+
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
      *
@@ -67,6 +70,25 @@ class JakartaServletFileUploadGetItemIteratorTest {
             sb.append("Content-Type: text/plain\r\n");
             sb.append("\r\n");
             sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Builds a complete multipart/related body that contains {@code partCount} identical parts.
+     *
+     * @param partCount number of parts to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMultiRelatedParts(final int partCount) {
+        final var sb = new StringBuilder();
+        for (int i = 1; i <= partCount; i++) {
+            sb.append("--").append(BOUNDARY).append("\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("Content-ID: <part").append(i).append("@example.org>\r\n");
+            sb.append("\r\n");
+            sb.append("Content of part ").append(i).append("\r\n");
         }
         sb.append("--").append(BOUNDARY).append("--\r\n");
         return sb.toString().getBytes(StandardCharsets.US_ASCII);
@@ -351,6 +373,28 @@ class JakartaServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of parts in a multipart/related request exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartRelatedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMultiRelatedParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE_RELATED);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet5/src/test/java/org/apache/commons/fileupload2/jakarta/servlet5/JakartaServletFileUploadGetItemIteratorTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
 import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -124,6 +125,43 @@ class JakartaServletFileUploadGetItemIteratorTest {
         final var upload = newUpload();
         final FileItemInputIterator iter = upload.getItemIterator(request);
         assertFalse(iter.hasNext(), "Expected no items in an empty multipart body");
+    }
+
+    /**
+     * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
+     * permitted count.
+     */
+    @Test
+    void testFileCountLimitExceededThrowsException() throws Exception {
+        final long maxFileCount = 2;
+        final var body = buildMultiFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
+    }
+
+    /**
+     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
+     */
+    @Test
+    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
+        final var body = buildMultiFileParts(2);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(1L);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        assertTrue(iter.hasNext());
+        iter.next(); // consume the first (allowed) item
+        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
@@ -56,6 +56,33 @@ class JakartaServletFileUploadGetItemIteratorTest {
     /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
 
+    /** Boundary value used for nested multipart/mixed parts. */
+    private static final String MIXED_BOUNDARY = "---9876";
+
+    /**
+     * Builds a complete multipart body that contains a single form-data part holding a nested multipart/mixed part with {@code fileCount} identical files.
+     *
+     * @param fileCount number of nested files to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMixedFileParts(final int fileCount) {
+        final var sb = new StringBuilder();
+        sb.append("--").append(BOUNDARY).append("\r\n");
+        sb.append("Content-Disposition: form-data; name=\"files\"\r\n");
+        sb.append("Content-Type: multipart/mixed; boundary=").append(MIXED_BOUNDARY).append("\r\n");
+        sb.append("\r\n");
+        for (int i = 1; i <= fileCount; i++) {
+            sb.append("--").append(MIXED_BOUNDARY).append("\r\n");
+            sb.append("Content-Disposition: attachment; filename=\"file").append(i).append(".txt\"\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("\r\n");
+            sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(MIXED_BOUNDARY).append("--\r\n");
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
      *
@@ -373,6 +400,28 @@ class JakartaServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of files in a nested multipart/mixed part exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartMixedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMixedFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
@@ -34,6 +34,8 @@ import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -129,11 +131,11 @@ class JakartaServletFileUploadGetItemIteratorTest {
 
     /**
      * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
-     * permitted count.
+     * permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
      */
-    @Test
-    void testFileCountLimitExceededThrowsException() throws Exception {
-        final long maxFileCount = 2;
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
         final var body = buildMultiFileParts((int) maxFileCount + 1);
         final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
         final var upload = newUpload();
@@ -147,21 +149,6 @@ class JakartaServletFileUploadGetItemIteratorTest {
         // The next hasNext() call triggers the limit check
         final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
         assertEquals(maxFileCount, ex.getPermitted());
-    }
-
-    /**
-     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
-     */
-    @Test
-    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
-        final var body = buildMultiFileParts(2);
-        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
-        final var upload = newUpload();
-        upload.setMaxFileCount(1L);
-        final FileItemInputIterator iter = upload.getItemIterator(request);
-        assertTrue(iter.hasNext());
-        iter.next(); // consume the first (allowed) item
-        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
@@ -53,6 +53,9 @@ class JakartaServletFileUploadGetItemIteratorTest {
     /** Content-type header value that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE = "multipart/form-data; boundary=" + BOUNDARY;
 
+    /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
+    private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
+
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
      *
@@ -67,6 +70,25 @@ class JakartaServletFileUploadGetItemIteratorTest {
             sb.append("Content-Type: text/plain\r\n");
             sb.append("\r\n");
             sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Builds a complete multipart/related body that contains {@code partCount} identical parts.
+     *
+     * @param partCount number of parts to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMultiRelatedParts(final int partCount) {
+        final var sb = new StringBuilder();
+        for (int i = 1; i <= partCount; i++) {
+            sb.append("--").append(BOUNDARY).append("\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("Content-ID: <part").append(i).append("@example.org>\r\n");
+            sb.append("\r\n");
+            sb.append("Content of part ").append(i).append("\r\n");
         }
         sb.append("--").append(BOUNDARY).append("--\r\n");
         return sb.toString().getBytes(StandardCharsets.US_ASCII);
@@ -351,6 +373,28 @@ class JakartaServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of parts in a multipart/related request exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartRelatedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMultiRelatedParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE_RELATED);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-jakarta-servlet6/src/test/java/org/apache/commons/fileupload2/jakarta/servlet6/JakartaServletFileUploadGetItemIteratorTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
 import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -124,6 +125,43 @@ class JakartaServletFileUploadGetItemIteratorTest {
         final var upload = newUpload();
         final FileItemInputIterator iter = upload.getItemIterator(request);
         assertFalse(iter.hasNext(), "Expected no items in an empty multipart body");
+    }
+
+    /**
+     * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
+     * permitted count.
+     */
+    @Test
+    void testFileCountLimitExceededThrowsException() throws Exception {
+        final long maxFileCount = 2;
+        final var body = buildMultiFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
+    }
+
+    /**
+     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
+     */
+    @Test
+    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
+        final var body = buildMultiFileParts(2);
+        final HttpServletRequest request = new JakartaMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(1L);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        assertTrue(iter.hasNext());
+        iter.next(); // consume the first (allowed) item
+        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**

--- a/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
@@ -27,14 +27,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.fileupload2.core.DiskFileItemFactory;
 import org.apache.commons.fileupload2.core.FileItemInput;
 import org.apache.commons.fileupload2.core.FileItemInputIterator;
 import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Tests for {@link JakartaServletFileUpload#getItemIterator(HttpServletRequest)}.
@@ -46,7 +47,6 @@ class JavaxServletFileUploadGetItemIteratorTest {
 
     /** Boundary value used throughout these tests. */
     private static final String BOUNDARY = "---1234";
-
     /** Content-type header value that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE = "multipart/form-data; boundary=" + BOUNDARY;
 
@@ -124,6 +124,43 @@ class JavaxServletFileUploadGetItemIteratorTest {
         final var upload = newUpload();
         final FileItemInputIterator iter = upload.getItemIterator(request);
         assertFalse(iter.hasNext(), "Expected no items in an empty multipart body");
+    }
+
+    /**
+     * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
+     * permitted count.
+     */
+    @Test
+    void testFileCountLimitExceededThrowsException() throws Exception {
+        final long maxFileCount = 2;
+        final var body = buildMultiFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
+    }
+
+    /**
+     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
+     */
+    @Test
+    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
+        final var body = buildMultiFileParts(2);
+        final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(1L);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        assertTrue(iter.hasNext());
+        iter.next(); // consume the first (allowed) item
+        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**

--- a/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
@@ -53,6 +53,32 @@ class JavaxServletFileUploadGetItemIteratorTest {
     private static final String CONTENT_TYPE = "multipart/form-data; boundary=" + BOUNDARY;
     /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
+    /** Boundary value used for nested multipart/mixed parts. */
+    private static final String MIXED_BOUNDARY = "---9876";
+
+    /**
+     * Builds a complete multipart body that contains a single form-data part holding a nested multipart/mixed part with {@code fileCount} identical files.
+     *
+     * @param fileCount number of nested files to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMixedFileParts(final int fileCount) {
+        final var sb = new StringBuilder();
+        sb.append("--").append(BOUNDARY).append("\r\n");
+        sb.append("Content-Disposition: form-data; name=\"files\"\r\n");
+        sb.append("Content-Type: multipart/mixed; boundary=").append(MIXED_BOUNDARY).append("\r\n");
+        sb.append("\r\n");
+        for (int i = 1; i <= fileCount; i++) {
+            sb.append("--").append(MIXED_BOUNDARY).append("\r\n");
+            sb.append("Content-Disposition: attachment; filename=\"file").append(i).append(".txt\"\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("\r\n");
+            sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(MIXED_BOUNDARY).append("--\r\n");
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
 
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
@@ -371,6 +397,28 @@ class JavaxServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of files in a nested multipart/mixed part exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartMixedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMixedFileParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
@@ -51,6 +51,8 @@ class JavaxServletFileUploadGetItemIteratorTest {
     private static final String BOUNDARY = "---1234";
     /** Content-type header value that matches {@link #BOUNDARY}. */
     private static final String CONTENT_TYPE = "multipart/form-data; boundary=" + BOUNDARY;
+    /** Content-type header value for multipart/related requests that matches {@link #BOUNDARY}. */
+    private static final String CONTENT_TYPE_RELATED = "multipart/related; boundary=" + BOUNDARY;
 
     /**
      * Builds a complete multipart body that contains {@code fileCount} identical file parts.
@@ -66,6 +68,25 @@ class JavaxServletFileUploadGetItemIteratorTest {
             sb.append("Content-Type: text/plain\r\n");
             sb.append("\r\n");
             sb.append("Content of file ").append(i).append("\r\n");
+        }
+        sb.append("--").append(BOUNDARY).append("--\r\n");
+        return sb.toString().getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Builds a complete multipart/related body that contains {@code partCount} identical parts.
+     *
+     * @param partCount number of parts to include
+     * @return raw multipart bytes encoded in US-ASCII
+     */
+    private static byte[] buildMultiRelatedParts(final int partCount) {
+        final var sb = new StringBuilder();
+        for (int i = 1; i <= partCount; i++) {
+            sb.append("--").append(BOUNDARY).append("\r\n");
+            sb.append("Content-Type: text/plain\r\n");
+            sb.append("Content-ID: <part").append(i).append("@example.org>\r\n");
+            sb.append("\r\n");
+            sb.append("Content of part ").append(i).append("\r\n");
         }
         sb.append("--").append(BOUNDARY).append("--\r\n");
         return sb.toString().getBytes(StandardCharsets.US_ASCII);
@@ -350,6 +371,28 @@ class JavaxServletFileUploadGetItemIteratorTest {
         assertEquals("field2", part3.getFieldName());
         assertTrue(part3.isFormField());
         assertFalse(iter.hasNext());
+    }
+
+    /**
+     * When the number of parts in a multipart/related request exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException}
+     * with the expected permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testMultipartRelatedFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
+        final var body = buildMultiRelatedParts((int) maxFileCount + 1);
+        final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE_RELATED);
+        final var upload = newUpload();
+        upload.setMaxFileCount(maxFileCount);
+        final FileItemInputIterator iter = upload.getItemIterator(request);
+        // Consume allowed items first
+        for (int i = 0; i < maxFileCount; i++) {
+            assertTrue(iter.hasNext());
+            iter.next();
+        }
+        // The next hasNext() call triggers the limit check
+        final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
+        assertEquals(maxFileCount, ex.getPermitted());
     }
 
     /**

--- a/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
+++ b/commons-fileupload2-javax/src/test/java/org/apache/commons/fileupload2/javax/JavaxServletFileUploadGetItemIteratorTest.java
@@ -36,6 +36,8 @@ import org.apache.commons.fileupload2.core.FileUploadByteCountLimitException;
 import org.apache.commons.fileupload2.core.FileUploadException;
 import org.apache.commons.fileupload2.core.FileUploadFileCountLimitException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link JakartaServletFileUpload#getItemIterator(HttpServletRequest)}.
@@ -128,11 +130,11 @@ class JavaxServletFileUploadGetItemIteratorTest {
 
     /**
      * When the number of uploaded files exceeds {@code maxFileCount}, iterating must throw a {@link FileUploadFileCountLimitException} with the expected
-     * permitted count.
+     * permitted count. Tested for maxFileCount values of 1, 2, 4, and 8.
      */
-    @Test
-    void testFileCountLimitExceededThrowsException() throws Exception {
-        final long maxFileCount = 2;
+    @ParameterizedTest
+    @ValueSource(longs = { 1, 2, 4, 8 })
+    void testFileCountLimitExceededThrowsException(final long maxFileCount) throws Exception {
         final var body = buildMultiFileParts((int) maxFileCount + 1);
         final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE);
         final var upload = newUpload();
@@ -146,21 +148,6 @@ class JavaxServletFileUploadGetItemIteratorTest {
         // The next hasNext() call triggers the limit check
         final var ex = assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
         assertEquals(maxFileCount, ex.getPermitted());
-    }
-
-    /**
-     * A file-count limit of 1 allows exactly one file; attempting to move to the second must throw {@link FileUploadFileCountLimitException}.
-     */
-    @Test
-    void testFileCountLimitOfOneThrowsOnSecondFile() throws Exception {
-        final var body = buildMultiFileParts(2);
-        final HttpServletRequest request = new JavaxMockHttpServletRequest(body, CONTENT_TYPE);
-        final var upload = newUpload();
-        upload.setMaxFileCount(1L);
-        final FileItemInputIterator iter = upload.getItemIterator(request);
-        assertTrue(iter.hasNext());
-        iter.next(); // consume the first (allowed) item
-        assertThrows(FileUploadFileCountLimitException.class, iter::hasNext);
     }
 
     /**


### PR DESCRIPTION
`FileItemInputIteratorImpl.findNextItem()` now uses the max file count.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create the initial cut of the unit tests; Claude Sonet 4.6 Medium.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
